### PR TITLE
Format error details as JSON responses #20

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/error/ErrorResponse.java
+++ b/src/main/java/org/springframework/samples/petclinic/error/ErrorResponse.java
@@ -1,0 +1,34 @@
+package org.springframework.samples.petclinic.error;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Standard error response object that will be returned to the client
+ * in case of security exceptions.
+ */
+public class ErrorResponse {
+
+    private final int code;
+    private final String message;
+
+    @JsonProperty("server_address")
+    private final String serverAddress;
+
+    public ErrorResponse(int code, String message, String serverAddress) {
+        this.code = code;
+        this.message = message;
+        this.serverAddress = serverAddress;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public String getServerAddress() {
+        return serverAddress;
+    }
+}

--- a/src/main/java/org/springframework/samples/petclinic/error/SecurityControllerAdvice.java
+++ b/src/main/java/org/springframework/samples/petclinic/error/SecurityControllerAdvice.java
@@ -1,0 +1,86 @@
+package org.springframework.samples.petclinic.error;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+/**
+ * Controller advice that handles security-related exceptions and formats
+ * them as standardized JSON responses.
+ */
+@RestControllerAdvice
+public class SecurityControllerAdvice {
+
+    /**
+     * Get the server's IP address.
+     *
+     * @return The server's IP address or "unknown" if it cannot be determined
+     */
+    private String getServerAddress() {
+        try {
+            return InetAddress.getLocalHost().getHostAddress();
+        } catch (UnknownHostException e) {
+            return "unknown";
+        }
+    }
+
+    /**
+     * Handle general authentication exceptions.
+     */
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<ErrorResponse> handleAuthenticationException(AuthenticationException ex) {
+        ErrorResponse errorResponse = new ErrorResponse(
+            HttpStatus.UNAUTHORIZED.value(),
+            ex.getMessage(),
+            getServerAddress()
+        );
+        return new ResponseEntity<>(errorResponse, HttpStatus.UNAUTHORIZED);
+    }
+
+    /**
+     * Handle bad credentials exception.
+     */
+    @ExceptionHandler(BadCredentialsException.class)
+    public ResponseEntity<ErrorResponse> handleBadCredentialsException(BadCredentialsException ex) {
+        ErrorResponse errorResponse = new ErrorResponse(
+            HttpStatus.UNAUTHORIZED.value(),
+            ex.getMessage(),
+            getServerAddress()
+        );
+        return new ResponseEntity<>(errorResponse, HttpStatus.UNAUTHORIZED);
+    }
+
+    /**
+     * Handle access denied exception.
+     */
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ErrorResponse> handleAccessDeniedException(AccessDeniedException ex) {
+        ErrorResponse errorResponse = new ErrorResponse(
+            HttpStatus.FORBIDDEN.value(),
+            ex.getMessage(),
+            getServerAddress()
+        );
+        return new ResponseEntity<>(errorResponse, HttpStatus.FORBIDDEN);
+    }
+
+    /**
+     * Catch-all handler for any other security-related exceptions.
+     */
+    @ExceptionHandler({Exception.class})
+    public ResponseEntity<ErrorResponse> handleSecurityException(Exception ex, HttpServletRequest request) {
+        ErrorResponse errorResponse = new ErrorResponse(
+            HttpStatus.INTERNAL_SERVER_ERROR.value(),
+            ex.getMessage(),
+            getServerAddress()
+        );
+        return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/test/java/org/springframework/samples/petclinic/error/SecurityControllerAdviceTest.java
+++ b/src/test/java/org/springframework/samples/petclinic/error/SecurityControllerAdviceTest.java
@@ -1,0 +1,155 @@
+package org.springframework.samples.petclinic.error;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.samples.petclinic.service.clinicService.ApplicationTestConfig;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Integration tests for {@link SecurityControllerAdvice}.
+ */
+@SpringBootTest
+@ContextConfiguration(classes = ApplicationTestConfig.class)
+@AutoConfigureMockMvc
+@Import(SecurityControllerAdviceTest.TestController.class)
+public class SecurityControllerAdviceTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private TestService testService;
+
+    /**
+     * Test controller to trigger exceptions for testing.
+     */
+    @RestController
+    public static class TestController {
+
+        private final TestService testService;
+
+        public TestController(TestService testService) {
+            this.testService = testService;
+        }
+
+        @GetMapping("/test/authentication")
+        public String testAuthentication() {
+            return testService.methodThatThrowsAuthenticationException();
+        }
+
+        @GetMapping("/test/bad-credentials")
+        public String testBadCredentials() {
+            return testService.methodThatThrowsBadCredentialsException();
+        }
+
+        @GetMapping("/test/access-denied")
+        public String testAccessDenied() {
+            return testService.methodThatThrowsAccessDeniedException();
+        }
+
+        @GetMapping("/test/illegal-state")
+        public String testInsufficientAuthentication() {
+            return testService.methodThatThrowsIllegalStateException();
+        }
+    }
+
+    /**
+     * Interface for mocking service that throws security exceptions.
+     */
+    public interface TestService {
+        String methodThatThrowsAuthenticationException();
+        String methodThatThrowsBadCredentialsException();
+        String methodThatThrowsAccessDeniedException();
+        String methodThatThrowsIllegalStateException();
+    }
+
+    @BeforeEach
+    public void setup() {
+        mockMvc = MockMvcBuilders.standaloneSetup(new TestController(testService))
+            .setControllerAdvice(new SecurityControllerAdvice())
+            .build();
+    }
+
+    @Test
+    public void testHandleAuthenticationException() throws Exception {
+        // Setup
+        AuthenticationException authenticationException = mock(AuthenticationException.class);
+        when(authenticationException.getMessage()).thenReturn("Authentication failed");
+        when(testService.methodThatThrowsAuthenticationException()).thenThrow(authenticationException);
+
+        // Test
+        mockMvc.perform(get("/test/authentication")
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isUnauthorized())
+            .andExpect(jsonPath("$.code", is(401)))
+            .andExpect(jsonPath("$.message", is("Authentication failed")))
+            .andExpect(jsonPath("$.server_address", notNullValue()));
+    }
+
+    @Test
+    public void testHandleBadCredentialsException() throws Exception {
+        // Setup
+        BadCredentialsException badCredentialsException = new BadCredentialsException("Bad credentials");
+        when(testService.methodThatThrowsBadCredentialsException()).thenThrow(badCredentialsException);
+
+        // Test
+        mockMvc.perform(get("/test/bad-credentials")
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isUnauthorized())
+            .andExpect(jsonPath("$.code", is(401)))
+            .andExpect(jsonPath("$.message", is("Bad credentials")))
+            .andExpect(jsonPath("$.server_address", notNullValue()));
+    }
+
+    @Test
+    public void testHandleAccessDeniedException() throws Exception {
+        // Setup
+        AccessDeniedException accessDeniedException = new AccessDeniedException("Access denied");
+        when(testService.methodThatThrowsAccessDeniedException()).thenThrow(accessDeniedException);
+
+        // Test
+        mockMvc.perform(get("/test/access-denied")
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.code", is(403)))
+            .andExpect(jsonPath("$.message", is("Access denied")))
+            .andExpect(jsonPath("$.server_address", notNullValue()));
+    }
+
+    @Test
+    public void testHandleIllegalStateException() throws Exception {
+        // Setup
+        IllegalStateException illegalStateException = new IllegalStateException("Illegal state exception");
+        when(testService.methodThatThrowsIllegalStateException()).thenThrow(illegalStateException);
+
+        // Test
+        mockMvc.perform(get("/test/illegal-state")
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isInternalServerError())
+            .andExpect(jsonPath("$.code", is(500)))
+            .andExpect(jsonPath("$.message", is("Illegal state exception")))
+            .andExpect(jsonPath("$.server_address", notNullValue()));
+    }
+}


### PR DESCRIPTION
Implement a security @ControllerAdvice that catches and handles security exceptions and format error details as JSON responses. The filter should format error details as JSON responses with the following properties: code - appropriate HTTP status code
message - error message
server_address - server IP address

FAIL_TO_PASS: SecurityControllerAdviceTest