### PR TITLE
Track failed authentication requests and enforces temporary lockouts when thresholds are exceeded. #21

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/security/AuthenticationFailureListener.java
+++ b/src/main/java/org/springframework/samples/petclinic/security/AuthenticationFailureListener.java
@@ -1,0 +1,38 @@
+package org.springframework.samples.petclinic.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.context.ApplicationListener;
+import org.springframework.security.authentication.event.AbstractAuthenticationFailureEvent;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Component
+public class AuthenticationFailureListener implements ApplicationListener<AbstractAuthenticationFailureEvent> {
+
+    private final LoginAttemptService loginAttemptService;
+
+    public AuthenticationFailureListener(LoginAttemptService loginAttemptService) {
+        this.loginAttemptService = loginAttemptService;
+    }
+
+    @Override
+    public void onApplicationEvent(AbstractAuthenticationFailureEvent event) {
+        String username = event.getAuthentication().getName();
+        loginAttemptService.registerFailedAttempt(username);
+    }
+
+    private HttpServletRequest getCurrentRequest() {
+        ServletRequestAttributes attributes =
+            (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+        return attributes != null ? attributes.getRequest() : null;
+    }
+
+    private String getClientIP(HttpServletRequest request) {
+        String xfHeader = request.getHeader("X-Forwarded-For");
+        if (xfHeader == null) {
+            return request.getRemoteAddr();
+        }
+        return xfHeader.split(",")[0];
+    }
+}

--- a/src/main/java/org/springframework/samples/petclinic/security/AuthenticationSuccessListener.java
+++ b/src/main/java/org/springframework/samples/petclinic/security/AuthenticationSuccessListener.java
@@ -1,0 +1,45 @@
+package org.springframework.samples.petclinic.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.context.ApplicationListener;
+import org.springframework.security.authentication.event.AuthenticationSuccessEvent;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Component
+public class AuthenticationSuccessListener implements ApplicationListener<AuthenticationSuccessEvent> {
+
+    private final LoginAttemptService loginAttemptService;
+
+    public AuthenticationSuccessListener(LoginAttemptService loginAttemptService) {
+        this.loginAttemptService = loginAttemptService;
+    }
+
+    @Override
+    public void onApplicationEvent(AuthenticationSuccessEvent event) {
+        String username = event.getAuthentication().getName();
+        loginAttemptService.registerSuccessfulLogin(username);
+
+        // Also reset IP tracking
+        HttpServletRequest request = getCurrentRequest();
+        if (request != null) {
+            String ip = getClientIP(request);
+            loginAttemptService.registerSuccessfulLogin(ip);
+        }
+    }
+
+    private HttpServletRequest getCurrentRequest() {
+        ServletRequestAttributes attributes =
+            (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+        return attributes != null ? attributes.getRequest() : null;
+    }
+
+    private String getClientIP(HttpServletRequest request) {
+        String xfHeader = request.getHeader("X-Forwarded-For");
+        if (xfHeader == null) {
+            return request.getRemoteAddr();
+        }
+        return xfHeader.split(",")[0];
+    }
+}

--- a/src/main/java/org/springframework/samples/petclinic/security/LoginAttemptFilter.java
+++ b/src/main/java/org/springframework/samples/petclinic/security/LoginAttemptFilter.java
@@ -1,0 +1,90 @@
+package org.springframework.samples.petclinic.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+public class LoginAttemptFilter extends OncePerRequestFilter {
+
+    private static final Logger logger = LoggerFactory.getLogger(LoginAttemptFilter.class);
+    private final LoginAttemptService loginAttemptService;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public LoginAttemptFilter(LoginAttemptService loginAttemptService) {
+        this.loginAttemptService = loginAttemptService;
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+
+        // Check if this is a login request with basic auth
+        String authHeader = request.getHeader("Authorization");
+        if (authHeader != null && authHeader.startsWith("Basic ")) {
+            // Extract username
+            String base64Credentials = authHeader.substring("Basic ".length()).trim();
+            String credentials = new String(Base64.getDecoder().decode(base64Credentials));
+            String username = credentials.split(":", 2)[0];
+
+            // Check if the username is locked
+            if (loginAttemptService.isLocked(username)) {
+                long remainingMinutes = loginAttemptService.getRemainingLockTime(username);
+                logger.warn("Blocked authentication attempt from locked account: {}", username);
+
+                // Send locked account response
+                Map<String, Object> errorDetails = new HashMap<>();
+                errorDetails.put("status", HttpStatus.TOO_MANY_REQUESTS.value());
+                errorDetails.put("error", "Too Many Attempts");
+                errorDetails.put("message", "Account is temporarily locked due to too many failed login attempts. " +
+                        "Please try again in " + remainingMinutes + " minutes.");
+
+                response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+                response.setContentType("application/json");
+                objectMapper.writeValue(response.getWriter(), errorDetails);
+                return;
+            }
+
+            // Check IP address too
+            String clientIP = getClientIP(request);
+            if (loginAttemptService.isLocked(clientIP)) {
+                long remainingMinutes = loginAttemptService.getRemainingLockTime(clientIP);
+                logger.warn("Blocked authentication attempt from locked IP: {}", clientIP);
+
+                // Send locked IP response
+                Map<String, Object> errorDetails = new HashMap<>();
+                errorDetails.put("status", HttpStatus.TOO_MANY_REQUESTS.value());
+                errorDetails.put("error", "Too Many Attempts");
+                errorDetails.put("message", "Too many failed login attempts from your IP address. " +
+                        "Please try again in " + remainingMinutes + " minutes.");
+
+                response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+                response.setContentType("application/json");
+                objectMapper.writeValue(response.getWriter(), errorDetails);
+                return;
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String getClientIP(HttpServletRequest request) {
+        String xfHeader = request.getHeader("X-Forwarded-For");
+        if (xfHeader == null) {
+            return request.getRemoteAddr();
+        }
+        return xfHeader.split(",")[0];
+    }
+}

--- a/src/main/java/org/springframework/samples/petclinic/security/LoginAttemptProperties.java
+++ b/src/main/java/org/springframework/samples/petclinic/security/LoginAttemptProperties.java
@@ -1,0 +1,37 @@
+package org.springframework.samples.petclinic.security;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "petclinic.security.lockout")
+public class LoginAttemptProperties {
+
+    private int maxAttempts = 5;
+    private int lockDurationMinutes = 15;
+    private boolean enabled = true;
+
+    public int getMaxAttempts() {
+        return maxAttempts;
+    }
+
+    public void setMaxAttempts(int maxAttempts) {
+        this.maxAttempts = maxAttempts;
+    }
+
+    public int getLockDurationMinutes() {
+        return lockDurationMinutes;
+    }
+
+    public void setLockDurationMinutes(int lockDurationMinutes) {
+        this.lockDurationMinutes = lockDurationMinutes;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/src/main/java/org/springframework/samples/petclinic/security/LoginAttemptService.java
+++ b/src/main/java/org/springframework/samples/petclinic/security/LoginAttemptService.java
@@ -1,0 +1,123 @@
+package org.springframework.samples.petclinic.security;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class LoginAttemptService {
+
+    private static final Logger logger = LoggerFactory.getLogger(LoginAttemptService.class);
+
+    private final Map<String, UserLoginStatus> loginAttempts = new ConcurrentHashMap<>();
+    private final LoginAttemptProperties properties;
+
+    public LoginAttemptService(LoginAttemptProperties properties) {
+        this.properties = properties;
+    }
+
+    /**
+     * Record a failed login attempt for a given username or IP
+     */
+    public void registerFailedAttempt(String key) {
+        if (!properties.isEnabled()) {
+            return;
+        }
+
+        UserLoginStatus status = loginAttempts.getOrDefault(key, new UserLoginStatus());
+        status.incrementFailedAttempts();
+
+        if (status.getFailedAttempts() >= properties.getMaxAttempts()) {
+            status.setLockedUntil(LocalDateTime.now().plusMinutes(properties.getLockDurationMinutes()));
+            logger.warn("Account locked for {}: too many failed attempts ({})", key, status.getFailedAttempts());
+        } else {
+            logger.info("Failed login attempt {} for {}", status.getFailedAttempts(), key);
+        }
+
+        loginAttempts.put(key, status);
+    }
+
+    /**
+     * Record a successful login attempt for a given username or IP
+     */
+    public void registerSuccessfulLogin(String key) {
+        loginAttempts.remove(key);
+        logger.info("Successful login for {}, resetting counter", key);
+    }
+
+    /**
+     * Check if a given username or IP is currently locked out
+     */
+    public boolean isLocked(String key) {
+        if (!properties.isEnabled()) {
+            return false;
+        }
+
+        UserLoginStatus status = loginAttempts.get(key);
+        if (status == null) {
+            return false;
+        }
+
+        if (status.getLockedUntil() != null) {
+            if (LocalDateTime.now().isAfter(status.getLockedUntil())) {
+                // Lock duration has expired, reset status
+                loginAttempts.remove(key);
+                return false;
+            }
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Get remaining lock time in minutes
+     */
+    public long getRemainingLockTime(String key) {
+        UserLoginStatus status = loginAttempts.get(key);
+        if (status != null && status.getLockedUntil() != null) {
+            LocalDateTime now = LocalDateTime.now();
+            if (now.isBefore(status.getLockedUntil())) {
+                // Calculate remaining minutes
+                return java.time.Duration.between(now, status.getLockedUntil()).toMinutes() + 1;
+            }
+        }
+        return 0;
+    }
+
+    /**
+     * Get the current failed attempt count
+     */
+    public int getFailedAttempts(String key) {
+        UserLoginStatus status = loginAttempts.get(key);
+        return status != null ? status.getFailedAttempts() : 0;
+    }
+
+    /**
+     * Helper class to track user login status
+     */
+    private static class UserLoginStatus {
+        private int failedAttempts;
+        private LocalDateTime lockedUntil;
+
+        public int getFailedAttempts() {
+            return failedAttempts;
+        }
+
+        public void incrementFailedAttempts() {
+            this.failedAttempts++;
+        }
+
+        public LocalDateTime getLockedUntil() {
+            return lockedUntil;
+        }
+
+        public void setLockedUntil(LocalDateTime lockedUntil) {
+            this.lockedUntil = lockedUntil;
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -48,3 +48,8 @@ logging.level.org.springframework=INFO
 # by default the authentication is disabled
 petclinic.security.enable=false
 
+# Login attempt and account lockout settings
+petclinic.security.lockout.enabled=true
+petclinic.security.lockout.max-attempts=5
+petclinic.security.lockout.lock-duration-minutes=15
+

--- a/src/test/java/org/springframework/samples/petclinic/security/AccountLockoutIntegrationTest.java
+++ b/src/test/java/org/springframework/samples/petclinic/security/AccountLockoutIntegrationTest.java
@@ -1,0 +1,128 @@
+package org.springframework.samples.petclinic.security;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.samples.petclinic.service.clinicService.ApplicationTestConfig;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+import java.util.Base64;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ContextConfiguration(classes = ApplicationTestConfig.class)
+@TestPropertySource(properties = {
+    "petclinic.security.enable=true",
+    "petclinic.security.lockout.enabled=true",
+    "petclinic.security.lockout.max-attempts=3",
+    "petclinic.security.lockout.lock-duration-minutes=5"
+})
+public class AccountLockoutIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    public void testFailedAttemptsLeadToAccountLockout() throws Exception {
+        String basicAuth = createBasicAuthHeader("testuser1", "wrongpassword");
+
+        // Make failed login attempts up to the limit (3 attempts as per test properties)
+        for (int i = 0; i < 3; i++) {
+            // Each request should return 401 Unauthorized
+            mockMvc.perform(get("/api/owners")
+                    .header("Authorization", basicAuth)
+                    .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized());
+        }
+
+        // After threshold is reached, the next attempt should return 429 Too Many Requests
+        MvcResult result = mockMvc.perform(get("/api/owners")
+                .header("Authorization", basicAuth)
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().is(HttpStatus.TOO_MANY_REQUESTS.value()))
+            .andExpect(jsonPath("$.status").value(HttpStatus.TOO_MANY_REQUESTS.value()))
+            .andExpect(jsonPath("$.error").value("Too Many Attempts"))
+            .andExpect(jsonPath("$.message").value(containsString("temporarily locked")))
+            .andReturn();
+
+        // Verify response contains information about remaining lock time
+        String responseBody = result.getResponse().getContentAsString();
+        assertTrue(responseBody.contains("minutes"),
+            "Response should contain information about lock duration");
+    }
+
+    @Test
+    public void testDifferentIpsNotAffectedByLockout() throws Exception {
+        String basicAuth = createBasicAuthHeader("testuser2", "wrongpassword");
+        // Lock one IP address
+        String lockedIp = "10.10.10.10";
+        for (int i = 0; i < 3; i++) {
+            mockMvc.perform(get("/api/owners")
+                    .with(remoteAddr(lockedIp))
+                    .header("Authorization", basicAuth)
+                    .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized());
+        }
+
+        // Verify this IP is now locked
+        mockMvc.perform(get("/api/owners")
+                .with(remoteAddr(lockedIp))
+                .header("Authorization", basicAuth)
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().is(HttpStatus.TOO_MANY_REQUESTS.value()));
+    }
+
+    @Test
+    public void testDifferentUsersNotAffectedByLockout() throws Exception {
+        String basicAuth = createBasicAuthHeader("testuser3", "wrongpassword");
+        // Lock one user
+        for (int i = 0; i < 3; i++) {
+            mockMvc.perform(get("/api/owners")
+                    .header("Authorization", basicAuth)
+                    .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized());
+        }
+
+        // Verify this user is now locked
+        mockMvc.perform(get("/api/owners")
+                .header("Authorization", basicAuth)
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().is(HttpStatus.TOO_MANY_REQUESTS.value()));
+
+        // Different user should still be able to attempt login
+        String differentUser = "anotheruser";
+        String differentAuthHeader = createBasicAuthHeader(differentUser, "wrongPassword");
+
+        mockMvc.perform(get("/api/owners")
+                .header("Authorization", differentAuthHeader)
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isUnauthorized()); // Not locked, just unauthorized
+    }
+
+    // Helper methods
+
+    private String createBasicAuthHeader(String username, String password) {
+        String credentials = username + ":" + password;
+        return "Basic " + Base64.getEncoder().encodeToString(credentials.getBytes());
+    }
+
+    private RequestPostProcessor remoteAddr(final String remoteAddr) {
+        return request -> {
+            request.setRemoteAddr(remoteAddr);
+            return request;
+        };
+    }
+}


### PR DESCRIPTION
Track failed authentication requests and enforces temporary lockouts when thresholds are exceeded. #21

Implement a filter that intercepts authentication requests, tracks failed attempts using an in-memory store, and enforces temporary lockouts when thresholds are exceeded. The solution should provide appropriate error messages to locked-out clients, log suspicious activity for monitoring. The implementation should be configurable and follow Spring Security best practices. Filter configuration requirements:

Configure Filter settings in application.properties. Lockout should be enabled with petclinic.security.lockout.enabled property Lockout max attempts to be configured with petclinic.security.lockout.max-attempts property

FAIL_TO_PASS: AccountLockoutIntegrationTest