### PR TITLE
Store user passwords hash instead of the actual password. #24

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/service/UserServiceImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/service/UserServiceImpl.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.samples.petclinic.model.User;
 import org.springframework.samples.petclinic.model.Role;
 import org.springframework.samples.petclinic.repository.UserRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,12 +14,23 @@ public class UserServiceImpl implements UserService {
     @Autowired
     private UserRepository userRepository;
 
+    /**
+     * Password encoder bean from BasicAuthenticationConfig
+     */
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
     @Override
     @Transactional
     public void saveUser(User user) {
 
         if(user.getRoles() == null || user.getRoles().isEmpty()) {
             throw new IllegalArgumentException("User must have at least a role set!");
+        }
+
+        // Hash the password before storing
+        if (user.getPassword() != null && !user.getPassword().isEmpty()) {
+            user.setPassword(passwordEncoder.encode(user.getPassword()));
         }
 
         for (Role role : user.getRoles()) {

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/UserRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/UserRestControllerTests.java
@@ -1,6 +1,8 @@
 package org.springframework.samples.petclinic.rest.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -10,21 +12,25 @@ import org.springframework.http.MediaType;
 import org.springframework.samples.petclinic.mapper.UserMapper;
 import org.springframework.samples.petclinic.model.User;
 import org.springframework.samples.petclinic.rest.advice.ExceptionControllerAdvice;
-import org.springframework.samples.petclinic.rest.controller.UserRestController;
+import org.springframework.samples.petclinic.rest.dto.UserDto;
 import org.springframework.samples.petclinic.service.UserService;
 import org.springframework.samples.petclinic.service.clinicService.ApplicationTestConfig;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest
 @ContextConfiguration(classes = ApplicationTestConfig.class)
 @WebAppConfiguration
+@TestPropertySource(properties = {"petclinic.security.enable=true"})
 class UserRestControllerTests {
 
     @Mock
@@ -35,6 +41,9 @@ class UserRestControllerTests {
 
     @Autowired
     private UserRestController userRestController;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
 
     private MockMvc mockMvc;
 
@@ -71,5 +80,33 @@ class UserRestControllerTests {
         this.mockMvc.perform(post("/api/users")
             .content(newVetAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void testPasswordIsHashed() throws Exception {
+        String plainPassword = "securePassword123";
+        User user = new User();
+        user.setUsername("testuser");
+        user.setPassword(plainPassword);
+        user.setEnabled(true);
+        user.addRole("OWNER_ADMIN");
+
+        ObjectMapper mapper = new ObjectMapper();
+        String userJson = mapper.writeValueAsString(userMapper.toUserDto(user));
+
+        String result = this.mockMvc.perform(post("/api/users")
+            .content(userJson)
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+            .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isCreated())
+            .andExpect(content().contentType("application/json"))
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        UserDto userDto = mapper.readValue(result, UserDto.class);
+
+        assertTrue(userDto.getPassword().startsWith("$2a"), "Password should be hashed");
     }
 }


### PR DESCRIPTION
Update UserService to store User password hash and not the actual password. Use default password encoder.

FAIL_TO_PASS: UserRestControllerTests