### PR TITLE
Add Custom Headers to All HTTP Responses #43

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/rest/filter/CustomHeaderFilter.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/filter/CustomHeaderFilter.java
@@ -1,0 +1,38 @@
+package org.springframework.samples.petclinic.rest.filter;
+
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+
+/**
+ * Filter to add custom headers to all HTTP responses.
+ * This filter adds headers like X-Custom-Header and X-Request-ID for compliance and monitoring purposes.
+ */
+@Component
+@Order(1) // High priority to ensure it runs early in the filter chain
+public class CustomHeaderFilter implements Filter {
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+
+        HttpServletResponse httpResponse = (HttpServletResponse) response;
+
+        // Add a static custom header
+        httpResponse.setHeader("X-Custom-Header", "PetClinic-API");
+
+        // Add a unique request ID for tracking/monitoring
+        httpResponse.setHeader("X-Request-ID", UUID.randomUUID().toString());
+
+        // Continue the filter chain
+        chain.doFilter(request, response);
+    }
+}

--- a/src/test/java/org/springframework/samples/petclinic/rest/filter/CustomHeaderFilterIntegrationTest.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/filter/CustomHeaderFilterIntegrationTest.java
@@ -1,0 +1,37 @@
+package org.springframework.samples.petclinic.rest.filter;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Integration test for {@link CustomHeaderFilter}
+ * This test verifies that the custom headers are added to all HTTP responses
+ * by using a real application context with all filters applied.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+class CustomHeaderFilterIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @WithMockUser(roles="OWNER_ADMIN")
+    void shouldAddCustomHeadersToResponse() throws Exception {
+        // When making any request to the API
+        mockMvc.perform(get("/api/pettypes"))
+                // Then the response should include our custom headers
+                .andExpect(status().isOk())
+                .andExpect(header().exists("X-Custom-Header"))
+                .andExpect(header().string("X-Custom-Header", "PetClinic-API"))
+                .andExpect(header().exists("X-Request-ID"));
+    }
+}

--- a/src/test/java/org/springframework/samples/petclinic/rest/filter/CustomHeaderFilterTest.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/filter/CustomHeaderFilterTest.java
@@ -1,0 +1,50 @@
+package org.springframework.samples.petclinic.rest.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.io.IOException;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Test class for {@link CustomHeaderFilter}
+ */
+class CustomHeaderFilterTest {
+
+    private CustomHeaderFilter filter;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private FilterChain filterChain;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        filter = new CustomHeaderFilter();
+    }
+
+    @Test
+    void shouldAddCustomHeadersToResponse() throws ServletException, IOException {
+        // When
+        filter.doFilter(request, response, filterChain);
+
+        // Then
+        verify(response).setHeader(eq("X-Custom-Header"), eq("PetClinic-API"));
+        verify(response).setHeader(eq("X-Request-ID"), any(String.class));
+        verify(filterChain).doFilter(any(), any());
+    }
+}


### PR DESCRIPTION
Implement a filter that adds custom headers to all HTTP responses for compliance and monitoring purposes. Ensure the filter adds a static header, "X-Custom-Header", with the value "PetClinic-API", and a unique request ID in the header "X-Request-ID" for tracking. Make sure this filter executes early in the filter chain.

FAIL_TO_PASS: org.springframework.samples.petclinic.rest.filter.CustomHeaderFilterIntegrationTest, org.springframework.samples.petclinic.rest.filter.CustomHeaderFilterTest