### PR TITLE
Implement Manual and Programmatic Cache Eviction Strategies #3

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/cache/CacheManagementService.java
+++ b/src/main/java/org/springframework/samples/petclinic/cache/CacheManagementService.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2002-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.cache;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.stereotype.Service;
+
+import java.util.Collection;
+
+/**
+ * Pet Clinic cache management service providing programmatic cache operations.
+ */
+@Service
+public class CacheManagementService {
+
+    private static final Logger logger = LoggerFactory.getLogger(CacheManagementService.class);
+
+    private final CacheManager cacheManager;
+
+    @Autowired
+    public CacheManagementService(CacheManager cacheManager) {
+        this.cacheManager = cacheManager;
+    }
+
+    public void evictCache(String cacheName, Object key) {
+        Cache cache = cacheManager.getCache(cacheName);
+        if (cache != null) {
+            if (key != null) {
+                cache.evict(key);
+                logger.info("Cache eviction completed - Cache: '{}', Key: '{}'", cacheName, key);
+            } else {
+                cache.clear();
+                logger.info("Cache clear completed - Cache: '{}'", cacheName);
+            }
+        } else {
+            logger.warn("Attempted to evict non-existent cache: '{}'", cacheName);
+        }
+    }
+
+    public void evictAllCaches() {
+        Collection<String> cacheNames = cacheManager.getCacheNames();
+        for (String cacheName : cacheNames) {
+            Cache cache = cacheManager.getCache(cacheName);
+            if (cache != null) {
+                cache.clear();
+                logger.info("Cleared cache: '{}'", cacheName);
+            }
+        }
+        logger.info("All caches evicted. Total caches cleared: {}", cacheNames.size());
+    }
+
+    public Collection<String> getCacheNames() {
+        return cacheManager.getCacheNames();
+    }
+}

--- a/src/main/java/org/springframework/samples/petclinic/cache/CacheScheduledService.java
+++ b/src/main/java/org/springframework/samples/petclinic/cache/CacheScheduledService.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2002-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.cache;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+/**
+ * Scheduled service for automatic cache invalidation.
+ * Can be enabled/disabled via application properties
+ */
+@Service
+@EnableScheduling
+public class CacheScheduledService {
+
+    private static final Logger logger = LoggerFactory.getLogger(CacheScheduledService.class);
+
+    private final CacheManagementService cacheManagementService;
+
+    @Autowired
+    public CacheScheduledService(CacheManagementService cacheManagementService) {
+        this.cacheManagementService = cacheManagementService;
+    }
+
+    @Scheduled(cron = "${petclinic.cache.scheduled.cron:0 0 2 * * ?}")
+    public void invalidateCache() {
+        logger.info("Executing cache invalidation");
+        try {
+            cacheManagementService.evictAllCaches();
+            logger.info("Daily cache invalidation completed successfully");
+        } catch (Exception e) {
+            logger.error("Error during daily cache invalidation", e);
+        }
+    }
+}

--- a/src/main/java/org/springframework/samples/petclinic/config/CacheConfig.java
+++ b/src/main/java/org/springframework/samples/petclinic/config/CacheConfig.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2002-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.config;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    public static final String VETS_CACHE = "vets";
+    public static final String OWNERS_CACHE = "owners";
+    public static final String PETS_CACHE = "pets";
+    public static final String VISITS_CACHE = "visits";
+    public static final String SPECIALTIES_CACHE = "specialties";
+    public static final String PET_TYPES_CACHE = "petTypes";
+}

--- a/src/main/java/org/springframework/samples/petclinic/rest/controller/CacheManagementRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/controller/CacheManagementRestController.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2002-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.rest.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.samples.petclinic.cache.CacheManagementService;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@CrossOrigin(exposedHeaders = "errors, content-type")
+@RequestMapping("/api/cache")
+@Tag(name = "Cache Management", description = "Cache management operations")
+public class CacheManagementRestController {
+
+    private final CacheManagementService cacheManagementService;
+
+    @Autowired
+    public CacheManagementRestController(CacheManagementService cacheManagementService) {
+        this.cacheManagementService = cacheManagementService;
+    }
+
+    @Operation(summary = "Clear all caches", description = "Clears all cache entries across all configured caches")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Successfully cleared all caches"),
+        @ApiResponse(responseCode = "500", description = "Error clearing caches")
+    })
+    @PreAuthorize("hasRole(@roles.ADMIN)")
+    @DeleteMapping
+    public ResponseEntity<Void> clearAllCaches() {
+        try {
+            cacheManagementService.evictAllCaches();
+            return new ResponseEntity<>(HttpStatus.OK);
+        } catch (Exception e) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -48,3 +48,7 @@ logging.level.org.springframework=INFO
 # by default the authentication is disabled
 petclinic.security.enable=false
 
+# Cache management configuration
+# Daily cache refresh cron (default: 2 AM daily)
+petclinic.cache.scheduled.cron=0 0 2 * * ?
+

--- a/src/test/java/org/springframework/samples/petclinic/cache/CacheScheduledServiceIntegrationTest.java
+++ b/src/test/java/org/springframework/samples/petclinic/cache/CacheScheduledServiceIntegrationTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2002-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.cache;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.samples.petclinic.model.Vet;
+import org.springframework.samples.petclinic.repository.VetRepository;
+import org.springframework.samples.petclinic.rest.dto.VetDto;
+import org.springframework.scheduling.annotation.ScheduledAnnotationBeanPostProcessor;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles({"hsqldb", "spring-data-jpa"})
+@TestPropertySource(properties = {
+    "petclinic.cache.scheduled.enabled=true",  // Enable scheduled caching for tests
+    "petclinic.security.enable=false"
+})
+@Transactional
+class CacheScheduledServiceIntegrationTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @MockitoBean
+    private VetRepository vetRepository;
+    
+    @Autowired
+    ScheduledAnnotationBeanPostProcessor beanPostProcessor;
+
+    private String apiBaseUrl;
+    private String cacheBaseUrl;
+
+    @BeforeEach
+    void setUp() {
+        apiBaseUrl = "http://localhost:" + port + "/petclinic/api";
+        cacheBaseUrl = "http://localhost:" + port + "/petclinic/api/cache";
+        restTemplate = restTemplate.withBasicAuth("admin", "admin");
+        restTemplate.exchange(cacheBaseUrl, HttpMethod.DELETE, null, Void.class);
+        reset(vetRepository);
+    }
+
+    @Test
+    void testDataUpdatedWhenTriggeringScheduledAnnotationBeanPostProcessor() throws Exception {
+        Vet mockVet = new Vet();
+        mockVet.setId(1);
+        mockVet.setFirstName("Scheduled");
+        mockVet.setLastName("Vet");
+        Collection<Vet> initialVets = Arrays.asList(mockVet);
+
+        when(vetRepository.findAll()).thenReturn(initialVets);
+
+        ResponseEntity<VetDto[]> initialResponse = restTemplate.getForEntity(
+            apiBaseUrl + "/vets", VetDto[].class);
+        assertEquals(HttpStatus.OK, initialResponse.getStatusCode());
+        assertEquals("Scheduled", initialResponse.getBody()[0].getFirstName());
+        verify(vetRepository, times(1)).findAll();
+
+        ResponseEntity<VetDto[]> cachedResponse = restTemplate.getForEntity(
+            apiBaseUrl + "/vets", VetDto[].class);
+        assertEquals(HttpStatus.OK, cachedResponse.getStatusCode());
+        verify(vetRepository, times(1)).findAll(); // Still cached
+
+        // Update mock data (simulating database change)
+        Vet updatedVet = new Vet();
+        updatedVet.setId(1);
+        updatedVet.setFirstName("PostProcessor");
+        updatedVet.setLastName("Vet");
+        Collection<Vet> updatedVets = Arrays.asList(updatedVet);
+        when(vetRepository.findAll()).thenReturn(updatedVets);
+
+        // invoke the scheduled method
+        assertFalse(beanPostProcessor.getScheduledTasks().isEmpty());
+        beanPostProcessor.getScheduledTasks().forEach(scheduledTask -> scheduledTask.getTask().getRunnable().run());
+
+        ResponseEntity<VetDto[]> afterScheduledResponse = restTemplate.getForEntity(
+            apiBaseUrl + "/vets", VetDto[].class);
+        assertEquals(HttpStatus.OK, afterScheduledResponse.getStatusCode());
+        assertEquals("PostProcessor", afterScheduledResponse.getBody()[0].getFirstName());
+
+        // Verify database was accessed again after scheduled invalidation
+        verify(vetRepository, times(2)).findAll(); // Scheduled invalidation worked
+    }
+}

--- a/src/test/java/org/springframework/samples/petclinic/cache/EntityCacheTestConfiguration.java
+++ b/src/test/java/org/springframework/samples/petclinic/cache/EntityCacheTestConfiguration.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2002-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.cache;
+
+import org.springframework.http.HttpStatus;
+
+import java.util.Collection;
+import java.util.function.Function;
+
+/**
+ * Configuration class that encapsulates entity-specific test data and operations
+ * for generic cache testing. This allows the same test logic to work with any entity type.
+ *
+ * @param <E> Entity type (e.g., Vet, Pet, Owner)
+ * @param <D> DTO type (e.g., VetDto, PetDto, OwnerDto)
+ */
+public class EntityCacheTestConfiguration<E, D> {
+    private final String entityName;
+    private final String apiEndpoint;
+    private final Function<TestDataBuilder, E> entityFactory;
+    private final Function<TestDataBuilder, D> dtoFactory;
+    private final Object repository;
+    private final HttpStatus expectedCreateStatus;
+    private final HttpStatus expectedUpdateStatus;
+    private final HttpStatus expectedDeleteStatus;
+
+    // Repository operation mocks
+    private final RepositoryOperations<E> repositoryOps;
+
+    public EntityCacheTestConfiguration(Builder<E, D> builder) {
+        this.entityName = builder.entityName;
+        this.apiEndpoint = builder.apiEndpoint;
+        this.entityFactory = builder.entityFactory;
+        this.dtoFactory = builder.dtoFactory;
+        this.repository = builder.repository;
+        this.expectedCreateStatus = builder.expectedCreateStatus;
+        this.expectedUpdateStatus = builder.expectedUpdateStatus;
+        this.expectedDeleteStatus = builder.expectedDeleteStatus;
+        this.repositoryOps = builder.repositoryOps;
+    }
+
+    // Getters
+    public String getEntityName() {
+        return entityName;
+    }
+
+    public String getApiEndpoint() {
+        return apiEndpoint;
+    }
+
+    public Function<TestDataBuilder, E> getEntityFactory() {
+        return entityFactory;
+    }
+
+    public Function<TestDataBuilder, D> getDtoFactory() {
+        return dtoFactory;
+    }
+
+    public Object getRepository() {
+        return repository;
+    }
+
+    public HttpStatus getExpectedCreateStatus() {
+        return expectedCreateStatus;
+    }
+
+    public HttpStatus getExpectedUpdateStatus() {
+        return expectedUpdateStatus;
+    }
+
+    public HttpStatus getExpectedDeleteStatus() {
+        return expectedDeleteStatus;
+    }
+
+    public RepositoryOperations<E> getRepositoryOps() {
+        return repositoryOps;
+    }
+
+    // Helper methods
+    public E createEntity(TestDataBuilder builder) {
+        return entityFactory.apply(builder);
+    }
+
+    public D createDto(TestDataBuilder builder) {
+        return dtoFactory.apply(builder);
+    }
+
+    // Builder pattern
+    public static <E, D> Builder<E, D> builder() {
+        return new Builder<>();
+    }
+
+    public static class Builder<E, D> {
+        private String entityName;
+        private String apiEndpoint;
+        private Function<TestDataBuilder, E> entityFactory;
+        private Function<TestDataBuilder, D> dtoFactory;
+        private Object repository;
+        private HttpStatus expectedCreateStatus = HttpStatus.CREATED;
+        private HttpStatus expectedUpdateStatus = HttpStatus.NO_CONTENT;
+        private HttpStatus expectedDeleteStatus = HttpStatus.NO_CONTENT;
+        private RepositoryOperations<E> repositoryOps;
+
+        public Builder<E, D> entityName(String entityName) {
+            this.entityName = entityName;
+            return this;
+        }
+
+        public Builder<E, D> apiEndpoint(String apiEndpoint) {
+            this.apiEndpoint = apiEndpoint;
+            return this;
+        }
+
+        public Builder<E, D> entityFactory(Function<TestDataBuilder, E> entityFactory) {
+            this.entityFactory = entityFactory;
+            return this;
+        }
+
+        public Builder<E, D> dtoFactory(Function<TestDataBuilder, D> dtoFactory) {
+            this.dtoFactory = dtoFactory;
+            return this;
+        }
+
+        public Builder<E, D> repository(Object repository) {
+            this.repository = repository;
+            return this;
+        }
+
+        public Builder<E, D> expectedCreateStatus(HttpStatus status) {
+            this.expectedCreateStatus = status;
+            return this;
+        }
+
+        public Builder<E, D> expectedUpdateStatus(HttpStatus status) {
+            this.expectedUpdateStatus = status;
+            return this;
+        }
+
+        public Builder<E, D> expectedDeleteStatus(HttpStatus status) {
+            this.expectedDeleteStatus = status;
+            return this;
+        }
+
+        public Builder<E, D> repositoryOperations(RepositoryOperations<E> repositoryOps) {
+            this.repositoryOps = repositoryOps;
+            return this;
+        }
+
+        public EntityCacheTestConfiguration<E, D> build() {
+            if (entityName == null || apiEndpoint == null || entityFactory == null || 
+                dtoFactory == null || repository == null || repositoryOps == null) {
+                throw new IllegalStateException("All required fields must be set");
+            }
+            return new EntityCacheTestConfiguration<>(this);
+        }
+    }
+
+    /**
+     * Interface for repository operations that can be mocked
+     */
+    public interface RepositoryOperations<E> {
+        void mockFindAll(Object repository, Collection<E> entities);
+        void mockFindAllSequential(Object repository, Collection<E> firstCall, Collection<E> secondCall);
+        void mockFindById(Object repository, Integer id, E entity);
+        void mockFindByIdSequential(Object repository, Integer id, E firstCall, E secondCall);
+        void mockSave(Object repository, E entity);
+        void mockDelete(Object repository, E entity);
+    }
+}

--- a/src/test/java/org/springframework/samples/petclinic/cache/GenericEntityCacheIntegrationTest.java
+++ b/src/test/java/org/springframework/samples/petclinic/cache/GenericEntityCacheIntegrationTest.java
@@ -1,0 +1,780 @@
+/*
+ * Copyright 2002-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.cache;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.*;
+import org.springframework.samples.petclinic.model.*;
+import org.springframework.samples.petclinic.repository.*;
+import org.springframework.samples.petclinic.rest.dto.*;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Generic Cache Testing Framework
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles({"hsqldb", "spring-data-jpa"})
+@TestPropertySource(properties = {
+    "petclinic.cache.scheduled.enabled=false",
+    "petclinic.security.enable=false"
+})
+@Transactional
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class GenericEntityCacheIntegrationTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @MockitoBean
+    private VetRepository vetRepository;
+
+    @MockitoBean
+    private PetTypeRepository petTypeRepository;
+
+    @MockitoBean
+    private OwnerRepository ownerRepository;
+
+    @MockitoBean
+    private SpecialtyRepository specialtyRepository;
+
+    @MockitoBean
+    private VisitRepository visitRepository;
+
+    @MockitoBean
+    private PetRepository petRepository;
+
+    private String baseUrl;
+    private String apiBaseUrl;
+
+    private Map<String, EntityHandler> entityHandlers;
+
+    @BeforeEach
+    void setUp() {
+        baseUrl = "http://localhost:" + port + "/petclinic/api/cache";
+        apiBaseUrl = "http://localhost:" + port + "/petclinic/api";
+        restTemplate = restTemplate.withBasicAuth("admin", "admin");
+        restTemplate.exchange(baseUrl, HttpMethod.DELETE, null, Void.class);
+        
+        entityHandlers = Map.of(
+            "Vet", new GenericEntityHandler<>(
+                "Vet", "/vets", vetRepository, VetRepository.class, Vet.class,
+                this::createVet, this::createVetDto, new VetRepositoryOperations()
+            ),
+            "PetType", new GenericEntityHandler<>(
+                "PetType", "/pettypes", petTypeRepository, PetTypeRepository.class, PetType.class,
+                this::createPetType, this::createPetTypeDto, new PetTypeRepositoryOperations()
+            ),
+            "Owner", new GenericEntityHandler<>(
+                "Owner", "/owners", ownerRepository, OwnerRepository.class, Owner.class,
+                this::createOwner, this::createOwnerDto, new OwnerRepositoryOperations()
+            ),
+            "Specialty", new GenericEntityHandler<>(
+                "Specialty", "/specialties", specialtyRepository, SpecialtyRepository.class, Specialty.class,
+                this::createSpecialty, this::createSpecialtyDto, new SpecialtyRepositoryOperations()
+            ),
+            "Visit", new GenericEntityHandler<>(
+                "Visit", "/visits", visitRepository, VisitRepository.class, Visit.class,
+                this::createVisit, this::createVisitDto, new VisitRepositoryOperations()
+            ),
+            "Pet", new GenericEntityHandler<>(
+                "Pet", "/pets", petRepository, PetRepository.class, Pet.class,
+                this::createPet, this::createPetDto, new PetRepositoryOperations()
+            )
+        );
+    }
+
+    @ParameterizedTest(name = "Cache Addition Test for {0}")
+    @MethodSource("getEntityHandlers")
+    void testCacheCorrectnessOnAddition(String entityName) {
+        // Skip entities that don't support creation (like Pet which has no POST endpoint)
+        if ("Pet".equals(entityName)) {
+            return; // Skip this test for Pet entity
+        }
+        
+        EntityHandler handler = entityHandlers.get(entityName);
+        handler.setupAdditionMocks();
+        EntityCacheTestConfiguration<Object, Object> config = handler.createConfiguration();
+
+        // First API call - should populate cache
+        ResponseEntity<Object[]> initialResponse = restTemplate.getForEntity(
+            apiBaseUrl + config.getApiEndpoint(), Object[].class);
+        assertEquals(HttpStatus.OK, initialResponse.getStatusCode());
+        assertNotNull(initialResponse.getBody());
+        assertEquals(1, initialResponse.getBody().length);
+
+        // Create DTO for new entity
+        Object newEntityDto = config.createDto(TestDataBuilder.withIdAndName(2, "New"));
+
+        // Perform POST request
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<Object> entity = new HttpEntity<>(newEntityDto, headers);
+
+        ResponseEntity<Object> addResponse = restTemplate.postForEntity(
+            apiBaseUrl + config.getApiEndpoint(), entity, Object.class);
+        assertEquals(config.getExpectedCreateStatus(), addResponse.getStatusCode());
+        assertNotNull(addResponse.getBody());
+
+        // Verify cache was invalidated and updated
+        ResponseEntity<Object[]> updatedResponse = restTemplate.getForEntity(
+            apiBaseUrl + config.getApiEndpoint(), Object[].class);
+        assertEquals(HttpStatus.OK, updatedResponse.getStatusCode());
+        assertNotNull(updatedResponse.getBody());
+        assertEquals(2, updatedResponse.getBody().length);
+
+        handler.verifyAdditionCalls();
+    }
+
+    @ParameterizedTest(name = "Cache Update Test for {0}")
+    @MethodSource("getEntityHandlers")
+    void testCacheCorrectnessOnUpdate(String entityName) {
+        EntityHandler handler = entityHandlers.get(entityName);
+        handler.setupUpdateMocks();
+        EntityCacheTestConfiguration<Object, Object> config = handler.createConfiguration();
+
+        // Load entities into cache
+        ResponseEntity<Object[]> entitiesResponse = restTemplate.getForEntity(
+            apiBaseUrl + config.getApiEndpoint(), Object[].class);
+        assertEquals(HttpStatus.OK, entitiesResponse.getStatusCode());
+
+        // Load individual entity into cache
+        ResponseEntity<Object> cachedEntityResponse = restTemplate.getForEntity(
+            apiBaseUrl + config.getApiEndpoint() + "/1", Object.class);
+        assertEquals(HttpStatus.OK, cachedEntityResponse.getStatusCode());
+
+        // Create update DTO
+        Object updateDto = config.createDto(TestDataBuilder.withIdAndName(1, "Updated"));
+
+        // Perform PUT request
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<Object> entity = new HttpEntity<>(updateDto, headers);
+
+        ResponseEntity<Object> updateResponse = restTemplate.exchange(
+            apiBaseUrl + config.getApiEndpoint() + "/1", HttpMethod.PUT, entity, Object.class);
+        assertEquals(config.getExpectedUpdateStatus(), updateResponse.getStatusCode());
+
+        // Verify cache was invalidated and reflects update
+        ResponseEntity<Object> refreshedResponse = restTemplate.getForEntity(
+            apiBaseUrl + config.getApiEndpoint() + "/1", Object.class);
+        assertEquals(HttpStatus.OK, refreshedResponse.getStatusCode());
+
+        ResponseEntity<Object[]> allEntitiesResponse = restTemplate.getForEntity(
+            apiBaseUrl + config.getApiEndpoint(), Object[].class);
+        assertEquals(HttpStatus.OK, allEntitiesResponse.getStatusCode());
+
+        handler.verifyUpdateCalls();
+    }
+
+    @ParameterizedTest(name = "Cache Deletion Test for {0}")
+    @MethodSource("getEntityHandlers")
+    void testCacheCorrectnessOnDeletion(String entityName) {
+        EntityHandler handler = entityHandlers.get(entityName);
+        handler.setupDeletionMocks();
+        EntityCacheTestConfiguration<Object, Object> config = handler.createConfiguration();
+
+        // Load entities into cache
+        ResponseEntity<Object[]> entitiesBeforeDeletion = restTemplate.getForEntity(
+            apiBaseUrl + config.getApiEndpoint(), Object[].class);
+        assertEquals(HttpStatus.OK, entitiesBeforeDeletion.getStatusCode());
+        assertEquals(2, entitiesBeforeDeletion.getBody().length);
+
+        // Load individual entity into cache
+        ResponseEntity<Object> individualEntityResponse = restTemplate.getForEntity(
+            apiBaseUrl + config.getApiEndpoint() + "/2", Object.class);
+        assertEquals(HttpStatus.OK, individualEntityResponse.getStatusCode());
+
+        // Perform DELETE request
+        ResponseEntity<Object> deleteResponse = restTemplate.exchange(
+            apiBaseUrl + config.getApiEndpoint() + "/2", HttpMethod.DELETE, null, Object.class);
+        assertEquals(config.getExpectedDeleteStatus(), deleteResponse.getStatusCode());
+
+        // Verify cache reflects deletion
+        ResponseEntity<Object[]> entitiesAfterDeletionResponse = restTemplate.getForEntity(
+            apiBaseUrl + config.getApiEndpoint(), Object[].class);
+        assertEquals(HttpStatus.OK, entitiesAfterDeletionResponse.getStatusCode());
+        assertEquals(1, entitiesAfterDeletionResponse.getBody().length);
+
+        // Verify individual entity lookup returns 404
+        ResponseEntity<Object> deletedEntityResponse = restTemplate.getForEntity(
+            apiBaseUrl + config.getApiEndpoint() + "/2", Object.class);
+        assertEquals(HttpStatus.NOT_FOUND, deletedEntityResponse.getStatusCode());
+
+        handler.verifyDeletionCalls();
+    }
+
+    @ParameterizedTest(name = "Cache Effectiveness Test for {0}")
+    @MethodSource("getEntityHandlers")
+    void testCacheEffectiveness(String entityName) {
+        EntityHandler handler = entityHandlers.get(entityName);
+        handler.setupEffectivenessMocks();
+        EntityCacheTestConfiguration<Object, Object> config = handler.createConfiguration();
+
+        // First call - should hit repository
+        ResponseEntity<Object[]> firstResponse = restTemplate.getForEntity(
+            apiBaseUrl + config.getApiEndpoint(), Object[].class);
+        assertEquals(HttpStatus.OK, firstResponse.getStatusCode());
+        assertEquals(1, firstResponse.getBody().length);
+
+        // Second call - should use cache
+        ResponseEntity<Object[]> secondResponse = restTemplate.getForEntity(
+            apiBaseUrl + config.getApiEndpoint(), Object[].class);
+        assertEquals(HttpStatus.OK, secondResponse.getStatusCode());
+        assertEquals(1, secondResponse.getBody().length);
+
+        // Test individual entity caching
+        ResponseEntity<Object> firstEntityResponse = restTemplate.getForEntity(
+            apiBaseUrl + config.getApiEndpoint() + "/1", Object.class);
+        assertEquals(HttpStatus.OK, firstEntityResponse.getStatusCode());
+
+        ResponseEntity<Object> secondEntityResponse = restTemplate.getForEntity(
+            apiBaseUrl + config.getApiEndpoint() + "/1", Object.class);
+        assertEquals(HttpStatus.OK, secondEntityResponse.getStatusCode());
+
+        handler.verifyEffectivenessCalls();
+    }
+
+    @ParameterizedTest(name = "Clear All Caches Test for {0}")
+    @MethodSource("getEntityHandlers")
+    void testClearAllCaches(String entityName) {
+        EntityHandler handler = entityHandlers.get(entityName);
+        EntityCacheTestConfiguration<Object, Object> config = handler.createConfiguration();
+        
+        Object mockEntity = config.createEntity(TestDataBuilder.withIdAndName(1, "Test"));
+        Collection<Object> mockEntities = Arrays.asList(mockEntity);
+
+        config.getRepositoryOps().mockFindAll(config.getRepository(), mockEntities);
+
+        ResponseEntity<Object[]> response1 = restTemplate.getForEntity(
+            apiBaseUrl + config.getApiEndpoint(), Object[].class);
+        assertEquals(HttpStatus.OK, response1.getStatusCode());
+        assertEquals(1, response1.getBody().length);
+
+        ResponseEntity<Object[]> response2 = restTemplate.getForEntity(
+            apiBaseUrl + config.getApiEndpoint(), Object[].class);
+        assertEquals(HttpStatus.OK, response2.getStatusCode());
+        assertEquals(1, response2.getBody().length);
+
+        ResponseEntity<Void> deleteResponse = restTemplate.exchange(
+            baseUrl, HttpMethod.DELETE, null, Void.class);
+        assertEquals(HttpStatus.OK, deleteResponse.getStatusCode());
+
+        ResponseEntity<Object[]> response3 = restTemplate.getForEntity(
+            apiBaseUrl + config.getApiEndpoint(), Object[].class);
+        assertEquals(HttpStatus.OK, response3.getStatusCode());
+        assertEquals(1, response3.getBody().length);
+
+        // Verification is implicit - if the test passes, the cache is working correctly
+    }
+
+    static Stream<Arguments> getEntityHandlers() {
+        return Stream.of(
+            Arguments.of("Vet"),
+            Arguments.of("PetType"),
+            Arguments.of("Owner"),
+            Arguments.of("Specialty"),
+            Arguments.of("Visit"),
+            Arguments.of("Pet")
+        );
+    }
+
+    private interface EntityHandler {
+        void setupAdditionMocks();
+        void setupUpdateMocks();
+        void setupDeletionMocks();
+        void setupEffectivenessMocks();
+        void verifyAdditionCalls();
+        void verifyUpdateCalls();
+        void verifyDeletionCalls();
+        void verifyEffectivenessCalls();
+        EntityCacheTestConfiguration<Object, Object> createConfiguration();
+    }
+
+    private static class GenericEntityHandler<R, E, D> implements EntityHandler {
+        private final String entityName;
+        private final String apiEndpoint;
+        private final R repository;
+        private final Function<TestDataBuilder, E> entityFactory;
+        private final Function<TestDataBuilder, D> dtoFactory;
+        private final EntityCacheTestConfiguration.RepositoryOperations<Object> repositoryOperations;
+
+        GenericEntityHandler(String entityName, String apiEndpoint, R repository,
+                           Class<R> repositoryClass, Class<E> entityClass,
+                           Function<TestDataBuilder, E> entityFactory, Function<TestDataBuilder, D> dtoFactory,
+                           EntityCacheTestConfiguration.RepositoryOperations<Object> repositoryOperations) {
+            this.entityName = entityName;
+            this.apiEndpoint = apiEndpoint;
+            this.repository = repository;
+            this.entityFactory = entityFactory;
+            this.dtoFactory = dtoFactory;
+            this.repositoryOperations = repositoryOperations;
+        }
+
+        @Override
+        public void setupAdditionMocks() {
+            E initialEntity = entityFactory.apply(TestDataBuilder.withIdAndName(1, "Initial"));
+            E newEntity = entityFactory.apply(TestDataBuilder.withIdAndName(2, "New"));
+            Collection<Object> initialEntities = Arrays.asList(initialEntity);
+            Collection<Object> updatedEntities = Arrays.asList(initialEntity, newEntity);
+            
+            // Setup sequential returns for findAll - first call returns 1, second call returns 2
+            repositoryOperations.mockFindAllSequential(repository, initialEntities, updatedEntities);
+            repositoryOperations.mockSave(repository, newEntity);
+        }
+
+        @Override
+        public void setupUpdateMocks() {
+            E originalEntity = entityFactory.apply(TestDataBuilder.withIdAndName(1, "Original"));
+            E updatedEntity = entityFactory.apply(TestDataBuilder.withIdAndName(1, "Updated"));
+            Collection<Object> originalEntities = Arrays.asList(originalEntity);
+            Collection<Object> updatedEntities = Arrays.asList(updatedEntity);
+            
+            repositoryOperations.mockFindAll(repository, originalEntities);
+            repositoryOperations.mockFindById(repository, 1, originalEntity);
+            repositoryOperations.mockSave(repository, updatedEntity);
+        }
+
+        @Override
+        public void setupDeletionMocks() {
+            E existingEntity = entityFactory.apply(TestDataBuilder.withIdAndName(1, "Existing"));
+            E entityToDelete = entityFactory.apply(TestDataBuilder.withIdAndName(2, "ToDelete"));
+            Collection<Object> initialEntities = Arrays.asList(existingEntity, entityToDelete);
+            Collection<Object> entitiesAfterDeletion = Arrays.asList(existingEntity);
+            
+            // Setup sequential returns for findAll - first call returns 2, second call returns 1
+            repositoryOperations.mockFindAllSequential(repository, initialEntities, entitiesAfterDeletion);
+            // Setup sequential returns for findById - first call returns entity, second call returns null (after deletion)
+            repositoryOperations.mockFindByIdSequential(repository, 2, entityToDelete, null);
+            repositoryOperations.mockDelete(repository, entityToDelete);
+        }
+
+        @Override
+        public void setupEffectivenessMocks() {
+            E mockEntity = entityFactory.apply(TestDataBuilder.withIdAndName(1, "Cached"));
+            Collection<Object> mockEntities = Arrays.asList(mockEntity);
+            
+            repositoryOperations.mockFindAll(repository, mockEntities);
+            repositoryOperations.mockFindById(repository, 1, mockEntity);
+        }
+
+        @Override
+        public void verifyAdditionCalls() {
+            // Verification is implicit - test passes if cache behavior is correct
+        }
+
+        @Override
+        public void verifyUpdateCalls() {
+            // Verification is implicit - test passes if cache behavior is correct
+        }
+
+        @Override
+        public void verifyDeletionCalls() {
+            // Verification is implicit - test passes if cache behavior is correct
+        }
+
+        @Override
+        public void verifyEffectivenessCalls() {
+            // Verification is implicit - test passes if cache behavior is correct
+        }
+
+        @Override
+        public EntityCacheTestConfiguration<Object, Object> createConfiguration() {
+            return EntityCacheTestConfiguration.<Object, Object>builder()
+                .entityName(entityName)
+                .apiEndpoint(apiEndpoint)
+                .entityFactory(builder -> entityFactory.apply(builder))
+                .dtoFactory(builder -> dtoFactory.apply(builder))
+                .repository(repository)
+                .expectedCreateStatus(HttpStatus.CREATED)
+                .expectedUpdateStatus(HttpStatus.NO_CONTENT)
+                .expectedDeleteStatus(HttpStatus.NO_CONTENT)
+                .repositoryOperations(repositoryOperations)
+                .build();
+        }
+    }
+
+    private Vet createVet(TestDataBuilder builder) {
+        Vet vet = new Vet();
+        vet.setId(builder.getId());
+        vet.setFirstName(builder.getName());
+        vet.setLastName("LastName");
+        return vet;
+    }
+
+    private VetDto createVetDto(TestDataBuilder builder) {
+        VetDto vetDto = new VetDto();
+        vetDto.setId(builder.getId());
+        vetDto.setFirstName(builder.getName());
+        vetDto.setLastName("LastName");
+        return vetDto;
+    }
+
+    private PetType createPetType(TestDataBuilder builder) {
+        PetType petType = new PetType();
+        petType.setId(builder.getId());
+        petType.setName(builder.getName());
+        return petType;
+    }
+
+    private PetTypeDto createPetTypeDto(TestDataBuilder builder) {
+        PetTypeDto petTypeDto = new PetTypeDto();
+        petTypeDto.setId(builder.getId());
+        petTypeDto.setName(builder.getName());
+        return petTypeDto;
+    }
+
+    private Owner createOwner(TestDataBuilder builder) {
+        Owner owner = new Owner();
+        owner.setId(builder.getId());
+        owner.setFirstName(builder.getName());
+        owner.setLastName("LastName");
+        owner.setAddress("123 Test Street");
+        owner.setCity("Test City");
+        owner.setTelephone("1234567890");
+        return owner;
+    }
+
+    private OwnerDto createOwnerDto(TestDataBuilder builder) {
+        OwnerDto ownerDto = new OwnerDto();
+        ownerDto.setId(builder.getId());
+        ownerDto.setFirstName(builder.getName());
+        ownerDto.setLastName("LastName");
+        ownerDto.setAddress("123 Test Street");
+        ownerDto.setCity("Test City");
+        ownerDto.setTelephone("1234567890");
+        ownerDto.setPets(new java.util.ArrayList<>());
+        return ownerDto;
+    }
+
+    private Specialty createSpecialty(TestDataBuilder builder) {
+        Specialty specialty = new Specialty();
+        specialty.setId(builder.getId());
+        specialty.setName(builder.getName());
+        return specialty;
+    }
+
+    private SpecialtyDto createSpecialtyDto(TestDataBuilder builder) {
+        SpecialtyDto specialtyDto = new SpecialtyDto();
+        specialtyDto.setId(builder.getId());
+        specialtyDto.setName(builder.getName());
+        return specialtyDto;
+    }
+
+    private Visit createVisit(TestDataBuilder builder) {
+        Visit visit = new Visit();
+        visit.setId(builder.getId());
+        visit.setDescription(builder.getName());
+        visit.setDate(java.time.LocalDate.now());
+        return visit;
+    }
+
+    private VisitDto createVisitDto(TestDataBuilder builder) {
+        VisitDto visitDto = new VisitDto();
+        visitDto.setId(builder.getId());
+        visitDto.setDescription(builder.getName());
+        visitDto.setDate(java.time.LocalDate.now());
+        return visitDto;
+    }
+
+    private Pet createPet(TestDataBuilder builder) {
+        Pet pet = new Pet();
+        pet.setId(builder.getId());
+        pet.setName(builder.getName());
+        pet.setBirthDate(java.time.LocalDate.of(2020, 1, 1));
+        
+        // Create a simple PetType for the pet
+        PetType petType = new PetType();
+        petType.setId(1);
+        petType.setName("Dog");
+        pet.setType(petType);
+        
+        return pet;
+    }
+
+    private PetDto createPetDto(TestDataBuilder builder) {
+        PetDto petDto = new PetDto();
+        petDto.setId(builder.getId());
+        petDto.setName(builder.getName());
+        petDto.setBirthDate(java.time.LocalDate.of(2020, 1, 1));
+        
+        // Create a simple PetTypeDto for the pet
+        PetTypeDto petTypeDto = new PetTypeDto();
+        petTypeDto.setId(1);
+        petTypeDto.setName("Dog");
+        petDto.setType(petTypeDto);
+        
+        petDto.setVisits(new java.util.ArrayList<>());
+        return petDto;
+    }
+
+    // Pet-specific repository operations
+    private static class PetRepositoryOperations implements EntityCacheTestConfiguration.RepositoryOperations<Object> {
+        @Override
+        @SuppressWarnings("unchecked")
+        public void mockFindAll(Object repository, Collection<Object> entities) {
+            when(((PetRepository) repository).findAll()).thenReturn((Collection) entities);
+        }
+        
+        @Override
+        @SuppressWarnings("unchecked")
+        public void mockFindAllSequential(Object repository, Collection<Object> firstCall, Collection<Object> secondCall) {
+            when(((PetRepository) repository).findAll())
+                .thenReturn((Collection) firstCall)
+                .thenReturn((Collection) secondCall);
+        }
+        
+        @Override
+        public void mockFindById(Object repository, Integer id, Object entity) {
+            when(((PetRepository) repository).findById(id)).thenReturn((Pet) entity);
+        }
+        
+        @Override
+        public void mockFindByIdSequential(Object repository, Integer id, Object firstCall, Object secondCall) {
+            when(((PetRepository) repository).findById(id))
+                .thenReturn((Pet) firstCall)
+                .thenReturn((Pet) secondCall);
+        }
+        
+        @Override
+        public void mockSave(Object repository, Object entity) {
+            doNothing().when((PetRepository) repository).save(any(Pet.class));
+        }
+        
+        @Override
+        public void mockDelete(Object repository, Object entity) {
+            doNothing().when((PetRepository) repository).delete(any(Pet.class));
+        }
+    }
+
+    // Visit-specific repository operations
+    private static class VisitRepositoryOperations implements EntityCacheTestConfiguration.RepositoryOperations<Object> {
+        @Override
+        @SuppressWarnings("unchecked")
+        public void mockFindAll(Object repository, Collection<Object> entities) {
+            when(((VisitRepository) repository).findAll()).thenReturn((Collection) entities);
+        }
+        
+        @Override
+        @SuppressWarnings("unchecked")
+        public void mockFindAllSequential(Object repository, Collection<Object> firstCall, Collection<Object> secondCall) {
+            when(((VisitRepository) repository).findAll())
+                .thenReturn((Collection) firstCall)
+                .thenReturn((Collection) secondCall);
+        }
+        
+        @Override
+        public void mockFindById(Object repository, Integer id, Object entity) {
+            when(((VisitRepository) repository).findById(id)).thenReturn((Visit) entity);
+        }
+        
+        @Override
+        public void mockFindByIdSequential(Object repository, Integer id, Object firstCall, Object secondCall) {
+            when(((VisitRepository) repository).findById(id))
+                .thenReturn((Visit) firstCall)
+                .thenReturn((Visit) secondCall);
+        }
+        
+        @Override
+        public void mockSave(Object repository, Object entity) {
+            doNothing().when((VisitRepository) repository).save(any(Visit.class));
+        }
+        
+        @Override
+        public void mockDelete(Object repository, Object entity) {
+            doNothing().when((VisitRepository) repository).delete(any(Visit.class));
+        }
+    }
+
+    // Vet-specific repository operations
+    private static class VetRepositoryOperations implements EntityCacheTestConfiguration.RepositoryOperations<Object> {
+        @Override
+        @SuppressWarnings("unchecked")
+        public void mockFindAll(Object repository, Collection<Object> entities) {
+            when(((VetRepository) repository).findAll()).thenReturn((Collection) entities);
+        }
+        
+        @Override
+        @SuppressWarnings("unchecked")
+        public void mockFindAllSequential(Object repository, Collection<Object> firstCall, Collection<Object> secondCall) {
+            when(((VetRepository) repository).findAll())
+                .thenReturn((Collection) firstCall)
+                .thenReturn((Collection) secondCall);
+        }
+        
+        @Override
+        public void mockFindById(Object repository, Integer id, Object entity) {
+            when(((VetRepository) repository).findById(id)).thenReturn((Vet) entity);
+        }
+        
+        @Override
+        public void mockFindByIdSequential(Object repository, Integer id, Object firstCall, Object secondCall) {
+            when(((VetRepository) repository).findById(id))
+                .thenReturn((Vet) firstCall)
+                .thenReturn((Vet) secondCall);
+        }
+        
+        @Override
+        public void mockSave(Object repository, Object entity) {
+            doNothing().when((VetRepository) repository).save(any(Vet.class));
+        }
+        
+        @Override
+        public void mockDelete(Object repository, Object entity) {
+            doNothing().when((VetRepository) repository).delete(any(Vet.class));
+        }
+    }
+
+    // PetType-specific repository operations
+    private static class PetTypeRepositoryOperations implements EntityCacheTestConfiguration.RepositoryOperations<Object> {
+        @Override
+        @SuppressWarnings("unchecked")
+        public void mockFindAll(Object repository, Collection<Object> entities) {
+            when(((PetTypeRepository) repository).findAll()).thenReturn((Collection) entities);
+        }
+        
+        @Override
+        @SuppressWarnings("unchecked")
+        public void mockFindAllSequential(Object repository, Collection<Object> firstCall, Collection<Object> secondCall) {
+            when(((PetTypeRepository) repository).findAll())
+                .thenReturn((Collection) firstCall)
+                .thenReturn((Collection) secondCall);
+        }
+        
+        @Override
+        public void mockFindById(Object repository, Integer id, Object entity) {
+            when(((PetTypeRepository) repository).findById(id)).thenReturn((PetType) entity);
+        }
+        
+        @Override
+        public void mockFindByIdSequential(Object repository, Integer id, Object firstCall, Object secondCall) {
+            when(((PetTypeRepository) repository).findById(id))
+                .thenReturn((PetType) firstCall)
+                .thenReturn((PetType) secondCall);
+        }
+        
+        @Override
+        public void mockSave(Object repository, Object entity) {
+            doNothing().when((PetTypeRepository) repository).save(any(PetType.class));
+        }
+        
+        @Override
+        public void mockDelete(Object repository, Object entity) {
+            doNothing().when((PetTypeRepository) repository).delete(any(PetType.class));
+        }
+    }
+
+    // Owner-specific repository operations
+    private static class OwnerRepositoryOperations implements EntityCacheTestConfiguration.RepositoryOperations<Object> {
+        @Override
+        @SuppressWarnings("unchecked")
+        public void mockFindAll(Object repository, Collection<Object> entities) {
+            when(((OwnerRepository) repository).findAll()).thenReturn((Collection) entities);
+        }
+        
+        @Override
+        @SuppressWarnings("unchecked")
+        public void mockFindAllSequential(Object repository, Collection<Object> firstCall, Collection<Object> secondCall) {
+            when(((OwnerRepository) repository).findAll())
+                .thenReturn((Collection) firstCall)
+                .thenReturn((Collection) secondCall);
+        }
+        
+        @Override
+        public void mockFindById(Object repository, Integer id, Object entity) {
+            when(((OwnerRepository) repository).findById(id)).thenReturn((Owner) entity);
+        }
+        
+        @Override
+        public void mockFindByIdSequential(Object repository, Integer id, Object firstCall, Object secondCall) {
+            when(((OwnerRepository) repository).findById(id))
+                .thenReturn((Owner) firstCall)
+                .thenReturn((Owner) secondCall);
+        }
+        
+        @Override
+        public void mockSave(Object repository, Object entity) {
+            doNothing().when((OwnerRepository) repository).save(any(Owner.class));
+        }
+        
+        @Override
+        public void mockDelete(Object repository, Object entity) {
+            doNothing().when((OwnerRepository) repository).delete(any(Owner.class));
+        }
+    }
+
+    // Specialty-specific repository operations
+    private static class SpecialtyRepositoryOperations implements EntityCacheTestConfiguration.RepositoryOperations<Object> {
+        @Override
+        @SuppressWarnings("unchecked")
+        public void mockFindAll(Object repository, Collection<Object> entities) {
+            when(((SpecialtyRepository) repository).findAll()).thenReturn((Collection) entities);
+        }
+        
+        @Override
+        @SuppressWarnings("unchecked")
+        public void mockFindAllSequential(Object repository, Collection<Object> firstCall, Collection<Object> secondCall) {
+            when(((SpecialtyRepository) repository).findAll())
+                .thenReturn((Collection) firstCall)
+                .thenReturn((Collection) secondCall);
+        }
+        
+        @Override
+        public void mockFindById(Object repository, Integer id, Object entity) {
+            when(((SpecialtyRepository) repository).findById(id)).thenReturn((Specialty) entity);
+        }
+        
+        @Override
+        public void mockFindByIdSequential(Object repository, Integer id, Object firstCall, Object secondCall) {
+            when(((SpecialtyRepository) repository).findById(id))
+                .thenReturn((Specialty) firstCall)
+                .thenReturn((Specialty) secondCall);
+        }
+        
+        @Override
+        public void mockSave(Object repository, Object entity) {
+            doNothing().when((SpecialtyRepository) repository).save(any(Specialty.class));
+        }
+        
+        @Override
+        public void mockDelete(Object repository, Object entity) {
+            doNothing().when((SpecialtyRepository) repository).delete(any(Specialty.class));
+        }
+    }
+}

--- a/src/test/java/org/springframework/samples/petclinic/cache/TestDataBuilder.java
+++ b/src/test/java/org/springframework/samples/petclinic/cache/TestDataBuilder.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2002-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.cache;
+
+/**
+ * Builder pattern for creating test data with flexible configuration.
+ * Supports common entity fields used in cache tests.
+ */
+public class TestDataBuilder {
+    private Integer id;
+    private String name;
+
+    public TestDataBuilder withId(Integer id) {
+        this.id = id;
+        return this;
+    }
+
+    public TestDataBuilder withName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    // Getters for the builder data
+    public Integer getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    // Static factory method for the common scenario used in tests
+    public static TestDataBuilder withIdAndName(Integer id, String name) {
+        return new TestDataBuilder().withId(id).withName(name);
+    }
+}

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/CacheManagementRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/CacheManagementRestControllerTests.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2016-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.rest.controller;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.samples.petclinic.model.Vet;
+import org.springframework.samples.petclinic.repository.VetRepository;
+import org.springframework.samples.petclinic.rest.dto.VetDto;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles({"hsqldb", "spring-data-jpa"})
+@TestPropertySource(properties = {
+    "petclinic.security.enable=false"
+})
+@Transactional
+class CacheManagementRestControllerTests {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @MockitoBean
+    private VetRepository vetRepository;
+
+    private String apiBaseUrl;
+    private String cacheBaseUrl;
+
+    @BeforeEach
+    void setUp() {
+        apiBaseUrl = "http://localhost:" + port + "/petclinic/api";
+        cacheBaseUrl = "http://localhost:" + port + "/petclinic/api/cache";
+        restTemplate = restTemplate.withBasicAuth("admin", "admin");
+        // Clear cache before each test
+        restTemplate.exchange(cacheBaseUrl, HttpMethod.DELETE, null, Void.class);
+        reset(vetRepository);
+    }
+
+    @Test
+    void testClearAllCaches_Success() throws Exception {
+        // Setup mock data
+        Vet mockVet = new Vet();
+        mockVet.setId(1);
+        mockVet.setFirstName("Test");
+        mockVet.setLastName("Vet");
+        Collection<Vet> vets = Arrays.asList(mockVet);
+        when(vetRepository.findAll()).thenReturn(vets);
+
+        // First call to populate cache
+        ResponseEntity<VetDto[]> initialResponse = restTemplate.getForEntity(
+            apiBaseUrl + "/vets", VetDto[].class);
+        assertEquals(HttpStatus.OK, initialResponse.getStatusCode());
+        assertEquals("Test", initialResponse.getBody()[0].getFirstName());
+        verify(vetRepository, times(1)).findAll();
+
+        // Second call should use cache (no additional repository call)
+        ResponseEntity<VetDto[]> cachedResponse = restTemplate.getForEntity(
+            apiBaseUrl + "/vets", VetDto[].class);
+        assertEquals(HttpStatus.OK, cachedResponse.getStatusCode());
+        verify(vetRepository, times(1)).findAll(); // Still only 1 call
+
+        // Clear all caches via REST API
+        ResponseEntity<Void> clearResponse = restTemplate.exchange(
+            cacheBaseUrl, HttpMethod.DELETE, null, Void.class);
+        
+        assertEquals(HttpStatus.OK, clearResponse.getStatusCode());
+
+        // After cache clear, next call should hit repository again
+        ResponseEntity<VetDto[]> afterClearResponse = restTemplate.getForEntity(
+            apiBaseUrl + "/vets", VetDto[].class);
+        assertEquals(HttpStatus.OK, afterClearResponse.getStatusCode());
+        verify(vetRepository, times(2)).findAll(); // Now 2 calls total
+    }
+
+    @Test
+    void testClearAllCaches_EmptyCaches() throws Exception {
+        // Clear caches when they are already empty
+        ResponseEntity<Void> clearResponse = restTemplate.exchange(
+            cacheBaseUrl, HttpMethod.DELETE, null, Void.class);
+        
+        assertEquals(HttpStatus.OK, clearResponse.getStatusCode());
+    }
+
+    @Test
+    void testClearAllCaches_WithPopulatedCache() throws Exception {
+        // Setup mock data
+        Vet mockVet1 = new Vet();
+        mockVet1.setId(1);
+        mockVet1.setFirstName("First");
+        mockVet1.setLastName("Vet");
+        
+        Vet mockVet2 = new Vet();
+        mockVet2.setId(2);
+        mockVet2.setFirstName("Second");
+        mockVet2.setLastName("Vet");
+        
+        Collection<Vet> vets = Arrays.asList(mockVet1, mockVet2);
+        when(vetRepository.findAll()).thenReturn(vets);
+
+        // Populate cache by making API calls
+        restTemplate.getForEntity(apiBaseUrl + "/vets", VetDto[].class);
+        verify(vetRepository, times(1)).findAll();
+
+        // Clear all caches
+        ResponseEntity<Void> clearResponse = restTemplate.exchange(
+            cacheBaseUrl, HttpMethod.DELETE, null, Void.class);
+        
+        assertEquals(HttpStatus.OK, clearResponse.getStatusCode());
+
+        // Verify cache was actually cleared by making another call
+        restTemplate.getForEntity(apiBaseUrl + "/vets", VetDto[].class);
+        verify(vetRepository, times(2)).findAll(); // Repository called again after cache clear
+    }
+
+    @Test
+    void testClearAllCaches_VerifyCacheInvalidation() throws Exception {
+        // Setup initial mock data
+        Vet initialVet = new Vet();
+        initialVet.setId(1);
+        initialVet.setFirstName("Initial");
+        initialVet.setLastName("Vet");
+        Collection<Vet> initialVets = Arrays.asList(initialVet);
+        when(vetRepository.findAll()).thenReturn(initialVets);
+
+        // First call to populate cache
+        ResponseEntity<VetDto[]> initialResponse = restTemplate.getForEntity(
+            apiBaseUrl + "/vets", VetDto[].class);
+        assertEquals(HttpStatus.OK, initialResponse.getStatusCode());
+        assertEquals("Initial", initialResponse.getBody()[0].getFirstName());
+        verify(vetRepository, times(1)).findAll();
+
+        // Update mock data (simulating database change)
+        Vet updatedVet = new Vet();
+        updatedVet.setId(1);
+        updatedVet.setFirstName("Updated");
+        updatedVet.setLastName("Vet");
+        Collection<Vet> updatedVets = Arrays.asList(updatedVet);
+        when(vetRepository.findAll()).thenReturn(updatedVets);
+
+        // Call again - should still return cached data
+        ResponseEntity<VetDto[]> cachedResponse = restTemplate.getForEntity(
+            apiBaseUrl + "/vets", VetDto[].class);
+        assertEquals(HttpStatus.OK, cachedResponse.getStatusCode());
+        assertEquals("Initial", cachedResponse.getBody()[0].getFirstName()); // Still cached
+        verify(vetRepository, times(1)).findAll(); // No additional repository call
+
+        // Clear cache
+        ResponseEntity<Void> clearResponse = restTemplate.exchange(
+            cacheBaseUrl, HttpMethod.DELETE, null, Void.class);
+        assertEquals(HttpStatus.OK, clearResponse.getStatusCode());
+
+        // Now should get updated data
+        ResponseEntity<VetDto[]> afterClearResponse = restTemplate.getForEntity(
+            apiBaseUrl + "/vets", VetDto[].class);
+        assertEquals(HttpStatus.OK, afterClearResponse.getStatusCode());
+        assertEquals("Updated", afterClearResponse.getBody()[0].getFirstName()); // Updated data
+        verify(vetRepository, times(2)).findAll(); // Repository called again
+    }
+
+    @Test
+    void testClearAllCaches_ExceptionHandling() throws Exception {
+        // This test verifies that the controller returns 500 status when an exception occurs
+        // Since we can't easily mock the CacheManagementService to throw an exception in this integration test,
+        // we'll test the basic functionality and document that exception handling returns 500 status
+        
+        // Clear caches - should work normally and return 200
+        ResponseEntity<Void> clearResponse = restTemplate.exchange(
+            cacheBaseUrl, HttpMethod.DELETE, null, Void.class);
+        
+        assertEquals(HttpStatus.OK, clearResponse.getStatusCode());
+        
+        // Note: In a real exception scenario, the controller would return HttpStatus.INTERNAL_SERVER_ERROR (500)
+        // This is verified by the controller implementation which catches Exception and returns 500 status
+    }
+}

--- a/src/test/java/org/springframework/samples/petclinic/service/clinicService/ClinicServiceJdbcTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/service/clinicService/ClinicServiceJdbcTests.java
@@ -17,6 +17,7 @@ package org.springframework.samples.petclinic.service.clinicService;
 
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 
 /**
  * <p> Integration test using the jdbc profile.
@@ -27,6 +28,9 @@ import org.springframework.test.context.ActiveProfiles;
  */
 @SpringBootTest
 @ActiveProfiles({"jdbc", "hsqldb"})
+@TestPropertySource(properties = {
+    "spring.cache.type=none"
+})
 class ClinicServiceJdbcTests extends AbstractClinicServiceTests {
 
 }

--- a/src/test/java/org/springframework/samples/petclinic/service/clinicService/ClinicServiceJpaTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/service/clinicService/ClinicServiceJpaTests.java
@@ -4,6 +4,7 @@ import jakarta.persistence.EntityManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 
 /**
  * <p> Integration test using the jpa profile.
@@ -16,6 +17,9 @@ import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @ActiveProfiles({"jpa", "hsqldb"})
+@TestPropertySource(properties = {
+    "spring.cache.type=none"
+})
 class ClinicServiceJpaTests extends AbstractClinicServiceTests {
 
     @Autowired

--- a/src/test/java/org/springframework/samples/petclinic/service/clinicService/ClinicServiceSpringDataJpaTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/service/clinicService/ClinicServiceSpringDataJpaTests.java
@@ -4,6 +4,7 @@ import jakarta.persistence.EntityManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 
 /**
  * <p> Integration test using the 'Spring Data' profile.
@@ -14,6 +15,9 @@ import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @ActiveProfiles({"spring-data-jpa", "hsqldb"})
+@TestPropertySource(properties = {
+    "spring.cache.type=none"
+})
 class ClinicServiceSpringDataJpaTests extends AbstractClinicServiceTests {
 
     @Autowired


### PR DESCRIPTION
Task Description:

Enable cache management in the Petclinic REST API by implementing automatic eviction on relevant entity updates and scheduled cache invalidation. Add caching to the clinic service and provide an admin endpoint for manual cache clearing. Cache entries should be automatically evicted when relevant entities are updated, and scheduled invalidation should provide additional flexibility for cache management.

Acceptance Criteria:

- Cache is added to clinic service with appropriate caching annotations.
- Cache entries are automatically evicted when relevant entities are updated.
- Admin endpoint DELETE /api/cache is implemented for manual cache clearing.
- Scheduled cache invalidation is implemented.
- Integration tests confirm correct automatic eviction and scheduled invalidation behavior.
- Documentation explains the caching strategy and admin cache management endpoint.

FAIL_TO_PASS: org.springframework.samples.petclinic.cache.CacheScheduledServiceIntegrationTest.java, org.springframework.samples.petclinic.cache.GenericEntityCacheIntegrationTest.java