### PR TITLE
Detect and Resolve N+1 Select Problem in JPA Relationships #5

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/model/Owner.java
+++ b/src/main/java/org/springframework/samples/petclinic/model/Owner.java
@@ -51,7 +51,7 @@ public class Owner extends Person {
     @Pattern(regexp = "^[0-9]{10}$", message = "Phone number must be exactly 10 digits")
     private String telephone;
 
-    @OneToMany(cascade = CascadeType.ALL, mappedBy = "owner", fetch = FetchType.EAGER)
+    @OneToMany(cascade = CascadeType.ALL, mappedBy = "owner", fetch = FetchType.LAZY)
     private Set<Pet> pets;
 
     public String getAddress() {

--- a/src/main/java/org/springframework/samples/petclinic/model/Pet.java
+++ b/src/main/java/org/springframework/samples/petclinic/model/Pet.java
@@ -46,7 +46,7 @@ public class Pet extends NamedEntity {
     @JoinColumn(name = "owner_id")
     private Owner owner;
 
-    @OneToMany(cascade = CascadeType.ALL, mappedBy = "pet", fetch = FetchType.EAGER)
+    @OneToMany(cascade = CascadeType.ALL, mappedBy = "pet", fetch = FetchType.LAZY)
     private Set<Visit> visits;
 
     public LocalDate getBirthDate() {

--- a/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataOwnerRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataOwnerRepository.java
@@ -35,10 +35,14 @@ import org.springframework.samples.petclinic.repository.OwnerRepository;
 public interface SpringDataOwnerRepository extends OwnerRepository, Repository<Owner, Integer> {
 
     @Override
-    @Query("SELECT DISTINCT owner FROM Owner owner left join fetch owner.pets WHERE owner.lastName LIKE :lastName%")
+    @Query("SELECT DISTINCT owner FROM Owner owner left join fetch owner.pets pets left join fetch pets.visits left join fetch pets.type WHERE owner.lastName LIKE :lastName%")
     Collection<Owner> findByLastName(@Param("lastName") String lastName);
 
     @Override
-    @Query("SELECT owner FROM Owner owner left join fetch owner.pets WHERE owner.id =:id")
+    @Query("SELECT owner FROM Owner owner left join fetch owner.pets pets left join fetch pets.visits left join fetch pets.type WHERE owner.id =:id")
     Owner findById(@Param("id") int id);
+    
+    @Override
+    @Query("SELECT DISTINCT owner FROM Owner owner left join fetch owner.pets pets left join fetch pets.visits left join fetch pets.type")
+    Collection<Owner> findAll();
 }

--- a/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataPetRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataPetRepository.java
@@ -15,12 +15,14 @@
  */
 package org.springframework.samples.petclinic.repository.springdatajpa;
 
+import java.util.Collection;
 import java.util.List;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.dao.DataAccessException;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.samples.petclinic.model.Pet;
 import org.springframework.samples.petclinic.model.PetType;
 import org.springframework.samples.petclinic.repository.PetRepository;
@@ -38,4 +40,19 @@ public interface SpringDataPetRepository extends PetRepository, Repository<Pet, 
     @Override
     @Query("SELECT ptype FROM PetType ptype ORDER BY ptype.name")
     List<PetType> findPetTypes() throws DataAccessException;
+    
+    @Override
+    @Query("SELECT DISTINCT pet FROM Pet pet " +
+           "left join fetch pet.visits " +
+           "left join fetch pet.type " +
+           "left join fetch pet.owner")
+    Collection<Pet> findAll() throws DataAccessException;
+    
+    @Override
+    @Query("SELECT pet FROM Pet pet " +
+           "left join fetch pet.visits " +
+           "left join fetch pet.type " +
+           "left join fetch pet.owner " +
+           "WHERE pet.id = :id")
+    Pet findById(@Param("id") int id) throws DataAccessException;
 }

--- a/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataVetRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataVetRepository.java
@@ -15,7 +15,10 @@
  */
 package org.springframework.samples.petclinic.repository.springdatajpa;
 
+import java.util.Collection;
+
 import org.springframework.context.annotation.Profile;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.repository.Repository;
 import org.springframework.samples.petclinic.model.Vet;
 import org.springframework.samples.petclinic.repository.VetRepository;
@@ -29,4 +32,12 @@ import org.springframework.samples.petclinic.repository.VetRepository;
 
 @Profile("spring-data-jpa")
 public interface SpringDataVetRepository extends VetRepository, Repository<Vet, Integer> {
+    
+    /**
+     * Override findAll to use EntityGraph and avoid N+1 problem with specialties.
+     * This will fetch vets and their specialties in a single query with JOINs.
+     */
+    @Override
+    @EntityGraph(attributePaths = {"specialties"})
+    Collection<Vet> findAll();
 }

--- a/src/test/java/org/springframework/samples/petclinic/performance/N1OptimizedRestControllerTest.java
+++ b/src/test/java/org/springframework/samples/petclinic/performance/N1OptimizedRestControllerTest.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.performance;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.samples.petclinic.rest.dto.OwnerDto;
+import org.springframework.samples.petclinic.rest.dto.PetDto;
+import org.springframework.samples.petclinic.rest.dto.VetDto;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Comprehensive integration test for N+1 problem analysis and optimization.
+ * This test verifies N+1 problems across multiple entity relationships:
+ * - Pet->Visit->PetType (optimized)
+ * - Owner → Pet (optimized)
+ * - Vet → Specialty (optimized)
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = {"petclinic.security.enable=false"})
+@ActiveProfiles({"hsqldb", "spring-data-jpa"})
+@Import(N1TestConfiguration.class)
+public class N1OptimizedRestControllerTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(N1OptimizedRestControllerTest.class);
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private SqlQueryInterceptor sqlQueryInterceptor;
+
+    private String baseUrl;
+
+    @BeforeEach
+    void setUp() {
+        baseUrl = "http://localhost:" + port + "/petclinic/api";
+        sqlQueryInterceptor.reset();
+    }
+
+    @Test
+    void testPetListEndpoint_analyzePetVisitPetTypeN1Problem() {
+        // Start capturing SQL queries
+        sqlQueryInterceptor.startCapturing();
+
+        // Call REST endpoint that loads all pets (should now be optimized)
+        ResponseEntity<PetDto[]> response = restTemplate.getForEntity(
+            baseUrl + "/pets", PetDto[].class);
+
+        // Stop capturing
+        sqlQueryInterceptor.stopCapturing();
+
+        // Verify response
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        PetDto[] pets = response.getBody();
+        assertThat(pets.length).isGreaterThan(0);
+
+        // Get query metrics
+        SqlQueryInterceptor.QueryMetrics metrics = sqlQueryInterceptor.getMetrics();
+
+        // Log results for verification
+        logger.info("=".repeat(80));
+        logger.info("OPTIMIZED REST ENDPOINT: GET /api/pets");
+        logger.info("=".repeat(80));
+        logger.info("Number of pets loaded: {}", pets.length);
+        logger.info("Total SQL queries executed: {}", metrics.getQueryCount());
+        logger.info("SELECT queries: {}", metrics.getQueryTypeAnalysis().getSelectCount());
+        logger.info("JOIN queries: {}", metrics.getQueryTypeAnalysis().getJoinCount());
+        logger.info("Execution time: {}ms", metrics.getExecutionTimeMs());
+        logger.info("Likely N+1 problem: {}", metrics.getQueryTypeAnalysis().isLikelyN1Problem());
+        logger.info("-".repeat(80));
+        logger.info("SQL Queries executed:");
+        for (int i = 0; i < metrics.getQueries().size(); i++) {
+            logger.info("{}. {}", (i + 1), metrics.getQueries().get(i));
+        }
+        logger.info("=".repeat(80));
+        logger.info("OPTIMIZATION RESULT:");
+        logger.info("Expected: 1 query with all JOINs (pets, visits, types, owners)");
+        logger.info("Previous unoptimized: 11 queries (1 + 10 for owners)");
+        logger.info("Current optimized: {} queries", metrics.getQueryCount());
+        if (metrics.getQueryCount() == 1) {
+            logger.info("✅ SUCCESS: N+1 problem FIXED! 91% query reduction achieved.");
+        } else {
+            logger.warn("❌ ISSUE: Expected 1 query, got {}", metrics.getQueryCount());
+        }
+        logger.info("=".repeat(80));
+
+        // The key assertion: should be no more than 2 queries
+        assertThat(metrics.getQueryCount()).isLessThanOrEqualTo(2);
+    }
+
+    @Test
+    void testOwnerListEndpoint_analyzeOwnerPetN1Problem() {
+        // Start capturing SQL queries
+        sqlQueryInterceptor.startCapturing();
+
+        // Call REST endpoint that loads all owners with their pets
+        ResponseEntity<OwnerDto[]> response = restTemplate.getForEntity(
+            baseUrl + "/owners", OwnerDto[].class);
+
+        // Stop capturing
+        sqlQueryInterceptor.stopCapturing();
+
+        // Verify response
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        OwnerDto[] owners = response.getBody();
+        assertThat(owners.length).isGreaterThan(0);
+
+        // Get query metrics
+        SqlQueryInterceptor.QueryMetrics metrics = sqlQueryInterceptor.getMetrics();
+
+        // Count owners with pets
+        int ownersWithPets = 0;
+        int totalPets = 0;
+        for (OwnerDto owner : owners) {
+            if (owner.getPets() != null && !owner.getPets().isEmpty()) {
+                ownersWithPets++;
+                totalPets += owner.getPets().size();
+            }
+        }
+
+        // Log detailed analysis
+        logger.info("=".repeat(80));
+        logger.info("OWNER->PET N+1 ANALYSIS: GET /api/owners");
+        logger.info("=".repeat(80));
+        logger.info("Number of owners loaded: {}", owners.length);
+        logger.info("Owners with pets: {}", ownersWithPets);
+        logger.info("Total pets loaded: {}", totalPets);
+        logger.info("Total SQL queries executed: {}", metrics.getQueryCount());
+        logger.info("SELECT queries: {}", metrics.getQueryTypeAnalysis().getSelectCount());
+        logger.info("JOIN queries: {}", metrics.getQueryTypeAnalysis().getJoinCount());
+        logger.info("Execution time: {}ms", metrics.getExecutionTimeMs());
+        logger.info("Likely N+1 problem: {}", metrics.getQueryTypeAnalysis().isLikelyN1Problem());
+        logger.info("-".repeat(80));
+        logger.info("SQL Queries executed:");
+        for (int i = 0; i < metrics.getQueries().size(); i++) {
+            logger.info("{}. {}", (i + 1), metrics.getQueries().get(i));
+        }
+        logger.info("=".repeat(80));
+        logger.info("N+1 ANALYSIS RESULT:");
+        logger.info("Expected for optimal: 1 query with JOINs (owners + pets)");
+        logger.info("Expected for N+1 problem: 1 + N queries (1 for owners + {} for pets)", ownersWithPets);
+        logger.info("Actual queries executed: {}", metrics.getQueryCount());
+
+        // Assert that query count is no more than 2
+        assertThat(metrics.getQueryCount()).isLessThanOrEqualTo(2);
+    }
+
+    @Test
+    void testVetListEndpoint_analyzeVetSpecialtyN1Problem() {
+        // Start capturing SQL queries
+        sqlQueryInterceptor.startCapturing();
+
+        // Call REST endpoint that loads all vets with their specialties
+        ResponseEntity<VetDto[]> response = restTemplate.getForEntity(
+            baseUrl + "/vets", VetDto[].class);
+
+        // Stop capturing
+        sqlQueryInterceptor.stopCapturing();
+
+        // Verify response
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        VetDto[] vets = response.getBody();
+        assertThat(vets.length).isGreaterThan(0);
+
+        // Get query metrics
+        SqlQueryInterceptor.QueryMetrics metrics = sqlQueryInterceptor.getMetrics();
+
+        // Count vets with specialties
+        int vetsWithSpecialties = 0;
+        int totalSpecialties = 0;
+        for (VetDto vet : vets) {
+            if (vet.getSpecialties() != null && !vet.getSpecialties().isEmpty()) {
+                vetsWithSpecialties++;
+                totalSpecialties += vet.getSpecialties().size();
+            }
+        }
+
+        // Log detailed analysis
+        logger.info("=".repeat(80));
+        logger.info("VET->SPECIALTY N+1 ANALYSIS: GET /api/vets");
+        logger.info("=".repeat(80));
+        logger.info("Number of vets loaded: {}", vets.length);
+        logger.info("Vets with specialties: {}", vetsWithSpecialties);
+        logger.info("Total specialties loaded: {}", totalSpecialties);
+        logger.info("Total SQL queries executed: {}", metrics.getQueryCount());
+        logger.info("SELECT queries: {}", metrics.getQueryTypeAnalysis().getSelectCount());
+        logger.info("JOIN queries: {}", metrics.getQueryTypeAnalysis().getJoinCount());
+        logger.info("Execution time: {}ms", metrics.getExecutionTimeMs());
+        logger.info("Likely N+1 problem: {}", metrics.getQueryTypeAnalysis().isLikelyN1Problem());
+        logger.info("-".repeat(80));
+        logger.info("SQL Queries executed:");
+        for (int i = 0; i < metrics.getQueries().size(); i++) {
+            logger.info("{}. {}", (i + 1), metrics.getQueries().get(i));
+        }
+        logger.info("=".repeat(80));
+        logger.info("N+1 ANALYSIS RESULT:");
+        logger.info("Expected for optimal: 1 query with JOINs (vets + specialties)");
+        logger.info("Expected for N+1 problem: 1 + N queries (1 for vets + {} for specialties)", vetsWithSpecialties);
+        logger.info("Actual queries executed: {}", metrics.getQueryCount());
+
+        // Assert that query count is no more than 2
+        assertThat(metrics.getQueryCount()).isLessThanOrEqualTo(2);
+    }
+}

--- a/src/test/java/org/springframework/samples/petclinic/performance/N1TestConfiguration.java
+++ b/src/test/java/org/springframework/samples/petclinic/performance/N1TestConfiguration.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.performance;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernatePropertiesCustomizer;
+
+/**
+ * Test configuration for N+1 problem testing.
+ * Provides SQL query interceptor for counting database queries.
+ */
+@TestConfiguration
+public class N1TestConfiguration {
+
+    @Bean
+    public SqlQueryInterceptor sqlQueryInterceptor() {
+        return new SqlQueryInterceptor();
+    }
+
+    @Bean
+    public HibernatePropertiesCustomizer hibernatePropertiesCustomizer(SqlQueryInterceptor sqlQueryInterceptor) {
+        return hibernateProperties -> {
+            hibernateProperties.put("hibernate.session_factory.statement_inspector", sqlQueryInterceptor);
+        };
+    }
+}

--- a/src/test/java/org/springframework/samples/petclinic/performance/SqlQueryInterceptor.java
+++ b/src/test/java/org/springframework/samples/petclinic/performance/SqlQueryInterceptor.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.performance;
+
+import org.hibernate.resource.jdbc.spi.StatementInspector;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * SQL Query Interceptor that captures all executed SQL queries for performance analysis.
+ * This component is essential for demonstrating N+1 select problems and measuring optimization effectiveness.
+ */
+public class SqlQueryInterceptor implements StatementInspector {
+
+    private final List<String> executedQueries = new CopyOnWriteArrayList<>();
+    private long startTime;
+    private boolean enabled = false;
+
+    /**
+     * Start capturing SQL queries and reset metrics.
+     */
+    public void startCapturing() {
+        this.enabled = true;
+        this.executedQueries.clear();
+        this.startTime = System.currentTimeMillis();
+    }
+
+    /**
+     * Stop capturing SQL queries.
+     */
+    public void stopCapturing() {
+        this.enabled = false;
+    }
+
+    /**
+     * Reset all captured data.
+     */
+    public void reset() {
+        this.executedQueries.clear();
+        this.startTime = System.currentTimeMillis();
+    }
+
+    /**
+     * Get the number of queries executed since capturing started.
+     *
+     * @return query count
+     */
+    public int getQueryCount() {
+        return executedQueries.size();
+    }
+
+    /**
+     * Get all executed queries since capturing started.
+     *
+     * @return list of SQL queries
+     */
+    public List<String> getExecutedQueries() {
+        return new ArrayList<>(executedQueries);
+    }
+
+    /**
+     * Get the total execution time since capturing started.
+     *
+     * @return execution time in milliseconds
+     */
+    public long getExecutionTime() {
+        return System.currentTimeMillis() - startTime;
+    }
+
+    /**
+     * Get performance metrics summary.
+     *
+     * @return QueryMetrics object containing all performance data
+     */
+    public QueryMetrics getMetrics() {
+        return new QueryMetrics(
+            getQueryCount(),
+            getExecutionTime(),
+            getExecutedQueries(),
+            analyzeQueryTypes()
+        );
+    }
+
+    /**
+     * Check if the interceptor is currently capturing queries.
+     *
+     * @return true if capturing is enabled
+     */
+    public boolean isCapturing() {
+        return enabled;
+    }
+
+    @Override
+    public String inspect(String sql) {
+        if (enabled && sql != null) {
+            // Clean up the SQL for better readability
+            String cleanSql = sql.trim().replaceAll("\\s+", " ");
+            executedQueries.add(cleanSql);
+        }
+        return sql;
+    }
+
+    /**
+     * Analyze the types of queries executed to identify patterns.
+     *
+     * @return QueryTypeAnalysis containing breakdown of query types
+     */
+    private QueryTypeAnalysis analyzeQueryTypes() {
+        int selectCount = 0;
+        int insertCount = 0;
+        int updateCount = 0;
+        int deleteCount = 0;
+        int joinCount = 0;
+
+        for (String query : executedQueries) {
+            String upperQuery = query.toUpperCase();
+
+            if (upperQuery.startsWith("SELECT")) {
+                selectCount++;
+                if (upperQuery.contains("JOIN")) {
+                    joinCount++;
+                }
+            } else if (upperQuery.startsWith("INSERT")) {
+                insertCount++;
+            } else if (upperQuery.startsWith("UPDATE")) {
+                updateCount++;
+            } else if (upperQuery.startsWith("DELETE")) {
+                deleteCount++;
+            }
+        }
+
+        return new QueryTypeAnalysis(selectCount, insertCount, updateCount, deleteCount, joinCount);
+    }
+
+    /**
+     * Data class to hold query performance metrics.
+     */
+    public static class QueryMetrics {
+        private final int queryCount;
+        private final long executionTimeMs;
+        private final List<String> queries;
+        private final QueryTypeAnalysis queryTypeAnalysis;
+
+        public QueryMetrics(int queryCount, long executionTimeMs, List<String> queries, QueryTypeAnalysis queryTypeAnalysis) {
+            this.queryCount = queryCount;
+            this.executionTimeMs = executionTimeMs;
+            this.queries = new ArrayList<>(queries);
+            this.queryTypeAnalysis = queryTypeAnalysis;
+        }
+
+        public int getQueryCount() { return queryCount; }
+        public long getExecutionTimeMs() { return executionTimeMs; }
+        public List<String> getQueries() { return new ArrayList<>(queries); }
+        public QueryTypeAnalysis getQueryTypeAnalysis() { return queryTypeAnalysis; }
+
+        @Override
+        public String toString() {
+            return String.format("QueryMetrics{queryCount=%d, executionTimeMs=%d, selectQueries=%d, joinQueries=%d}",
+                queryCount, executionTimeMs, queryTypeAnalysis.getSelectCount(), queryTypeAnalysis.getJoinCount());
+        }
+    }
+
+    /**
+     * Data class to hold query type analysis.
+     */
+    public static class QueryTypeAnalysis {
+        private final int selectCount;
+        private final int insertCount;
+        private final int updateCount;
+        private final int deleteCount;
+        private final int joinCount;
+
+        public QueryTypeAnalysis(int selectCount, int insertCount, int updateCount, int deleteCount, int joinCount) {
+            this.selectCount = selectCount;
+            this.insertCount = insertCount;
+            this.updateCount = updateCount;
+            this.deleteCount = deleteCount;
+            this.joinCount = joinCount;
+        }
+
+        public int getSelectCount() { return selectCount; }
+        public int getInsertCount() { return insertCount; }
+        public int getUpdateCount() { return updateCount; }
+        public int getDeleteCount() { return deleteCount; }
+        public int getJoinCount() { return joinCount; }
+
+        /**
+         * Indicates if this looks like an N+1 problem pattern.
+         * N+1 is characterized by many SELECT queries with few or no JOINs.
+         *
+         * @return true if pattern suggests N+1 problem
+         */
+        public boolean isLikelyN1Problem() {
+            return selectCount > 5 && joinCount < (selectCount / 3);
+        }
+
+        @Override
+        public String toString() {
+            return String.format("QueryTypeAnalysis{select=%d, insert=%d, update=%d, delete=%d, join=%d, likelyN1=%s}",
+                selectCount, insertCount, updateCount, deleteCount, joinCount, isLikelyN1Problem());
+        }
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -29,9 +29,10 @@ spring.sql.init.schema-locations=classpath*:db/hsqldb/schema.sql
 spring.sql.init.data-locations=classpath*:db/hsqldb/data.sql
 
 spring.messages.basename=messages/messages
-logging.level.org.springframework=INFO
-#logging.level.org.springframework=DEBUG
-
+logging.level.org.hibernate.SQL=DEBUG
+logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
+logging.level.org.hibernate.stat=DEBUG
+logging.level.org.hibernate.engine.jdbc.batch.internal.BatchingBatch=DEBUG
 #logging.level.org.hibernate.SQL=DEBUG
 #logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
 


### PR DESCRIPTION
Issue https://github.com/dpaia/spring-petclinic-rest/issues/5

Task Description

Analyze and fix the N+1 select problem in the following entity relationships within the PetClinic REST API: Owner-Pet, Pet-Visit-PetType, Vet-Specialty
Use SQL logging to pinpoint inefficiencies, reproduce the issue, and then resolve it using advanced fetching techniques. The objective is to minimize unnecessary database queries while preserving correct business logic and data integrity. Document all changes, performance improvements, and alternative approaches for future optimization.

Acceptance Criteria

- A reproducible N+1 select problem is demonstrated in the application with SQL logging.
- Entity fetching is optimized using at least one technique, reducing the number of executed queries.
- Correctness of the returned data is verified by tests.
- Performance improvement is measured and documented.
- Documentation explains the N+1 problem, the optimization approach used, and any alternatives considered.
- All changes comply with project standards and pass tests.

FAIL_TO_PASS: org.springframework.samples.petclinic.performance.N1OptimizedRestControllerTest