### PR TITLE
Implement hybrid multi layer caching with Caffeine and Redis #7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
         <jackson-databind-nullable.version>0.2.6</jackson-databind-nullable.version>
         <mapstruct.version>1.6.3</mapstruct.version>
         <jaxb-api.version>2.3.1</jaxb-api.version>
+        <testcontainers.version>1.20.4</testcontainers.version>
 
         <!-- Maven plugins and supporting properties -->
         <maven.checkstyle-plugin.version>3.6.0</maven.checkstyle-plugin.version>
@@ -68,6 +69,10 @@
             <artifactId>spring-boot-starter-cache</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
@@ -88,6 +93,24 @@
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
 
+        <!-- Redis and caching dependencies -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-redis</artifactId>
+        </dependency>
+        <!-- Testcontainers for Redis integration testing -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
 
         <!-- Data stores and supporting libs -->
         <dependency>

--- a/src/main/java/org/springframework/samples/petclinic/config/HybridCacheConfig.java
+++ b/src/main/java/org/springframework/samples/petclinic/config/HybridCacheConfig.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+
+import java.time.Duration;
+
+/**
+ * Configuration for hybrid caching system combining L1 (Caffeine) and L2 (Redis) caches.
+ */
+@Configuration
+@EnableCaching
+@ConditionalOnProperty(prefix = "petclinic.cache.hybrid", name = "enabled", havingValue = "true")
+public class HybridCacheConfig {
+    /**
+     * L1 Cache Manager using Caffeine for fast local access with TTL and size limits.
+     */
+    @Bean("l1CacheManager")
+    @Primary
+    public CacheManager l1CacheManager() {
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager(
+            "vets", "vetById",
+            "owners", "ownerById", "ownersByLastName",
+            "pets", "petById",
+            "petTypes", "petTypeById",
+            "specialties", "specialtyById", "specialtiesByNameIn",
+            "visits", "visitById", "visitsByPetId"
+        );
+
+        // Configure Caffeine cache spec with default TTL and size limits
+        String cacheSpec = "maximumSize=1000,expireAfterWrite=600s,expireAfterAccess=30s,recordStats";
+
+        cacheManager.setCacheSpecification(cacheSpec);
+
+        return cacheManager;
+    }
+
+    /**
+     * L2 Cache Manager using Redis for distributed caching.
+     */
+    @Bean("l2CacheManager")
+    @ConditionalOnProperty(name = "spring.data.redis.host")
+    public CacheManager l2RedisCacheManager(RedisConnectionFactory redisConnectionFactory) {
+        // Configure ObjectMapper with JSR310 module for LocalDate support
+        com.fasterxml.jackson.databind.ObjectMapper objectMapper = new com.fasterxml.jackson.databind.ObjectMapper();
+        objectMapper.registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule());
+        objectMapper.disable(com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        objectMapper.activateDefaultTyping(
+            objectMapper.getPolymorphicTypeValidator(),
+            com.fasterxml.jackson.databind.ObjectMapper.DefaultTyping.NON_FINAL,
+            com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY
+        );
+
+        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+
+        RedisCacheConfiguration cacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+            .entryTtl(Duration.ofSeconds(3600)) // 1 hour default TTL
+            .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(serializer))
+            .disableCachingNullValues(); // Don't cache null values
+
+        return RedisCacheManager.builder(redisConnectionFactory)
+            .cacheDefaults(cacheConfiguration)
+            .build();
+    }
+}

--- a/src/main/java/org/springframework/samples/petclinic/service/ClinicServiceImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/service/ClinicServiceImpl.java
@@ -16,6 +16,9 @@
 package org.springframework.samples.petclinic.service;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.orm.ObjectRetrievalFailureException;
@@ -64,138 +67,230 @@ public class ClinicServiceImpl implements ClinicService {
 
     @Override
     @Transactional(readOnly = true)
+    @Caching(cacheable = {
+        @Cacheable(cacheNames = "pets", cacheManager = "l1CacheManager"),
+        @Cacheable(cacheNames = "pets", cacheManager = "l2CacheManager")
+    })
     public Collection<Pet> findAllPets() throws DataAccessException {
         return petRepository.findAll();
     }
 
     @Override
     @Transactional
+    @Caching(evict = {
+        @CacheEvict(value = {"pets", "petById"}, allEntries = true, cacheManager = "l1CacheManager"),
+        @CacheEvict(value = {"pets", "petById"}, allEntries = true, cacheManager = "l2CacheManager")
+    })
     public void deletePet(Pet pet) throws DataAccessException {
         petRepository.delete(pet);
     }
 
     @Override
     @Transactional(readOnly = true)
+    @Caching(cacheable = {
+        @Cacheable(cacheNames = "visitById", key = "#visitId", cacheManager = "l1CacheManager"),
+        @Cacheable(cacheNames = "visitById", key = "#visitId", cacheManager = "l2CacheManager")
+    })
     public Visit findVisitById(int visitId) throws DataAccessException {
         return findEntityById(() -> visitRepository.findById(visitId));
     }
 
     @Override
     @Transactional(readOnly = true)
+    @Caching(cacheable = {
+        @Cacheable(cacheNames = "visits", cacheManager = "l1CacheManager"),
+        @Cacheable(cacheNames = "visits", cacheManager = "l2CacheManager")
+    })
     public Collection<Visit> findAllVisits() throws DataAccessException {
         return visitRepository.findAll();
     }
 
     @Override
     @Transactional
+    @Caching(evict = {
+        @CacheEvict(value = {"visits", "visitById", "visitsByPetId"}, allEntries = true, cacheManager = "l1CacheManager"),
+        @CacheEvict(value = {"visits", "visitById", "visitsByPetId"}, allEntries = true, cacheManager = "l2CacheManager")
+    })
     public void deleteVisit(Visit visit) throws DataAccessException {
         visitRepository.delete(visit);
     }
 
     @Override
     @Transactional(readOnly = true)
+    @Caching(cacheable = {
+        @Cacheable(cacheNames = "vetById", key = "#id", cacheManager = "l1CacheManager"),
+        @Cacheable(cacheNames = "vetById", key = "#id", cacheManager = "l2CacheManager")
+    })
     public Vet findVetById(int id) throws DataAccessException {
         return findEntityById(() -> vetRepository.findById(id));
     }
 
     @Override
     @Transactional(readOnly = true)
+    @Caching(cacheable = {
+        @Cacheable(cacheNames = "vets", cacheManager = "l1CacheManager"),
+        @Cacheable(cacheNames = "vets", cacheManager = "l2CacheManager")
+    })
     public Collection<Vet> findAllVets() throws DataAccessException {
         return vetRepository.findAll();
     }
 
     @Override
     @Transactional
+    @Caching(evict = {
+        @CacheEvict(value = {"vets", "vetById"}, allEntries = true, cacheManager = "l1CacheManager"),
+        @CacheEvict(value = {"vets", "vetById"}, allEntries = true, cacheManager = "l2CacheManager")
+    })
     public void saveVet(Vet vet) throws DataAccessException {
         vetRepository.save(vet);
     }
 
     @Override
     @Transactional
+    @Caching(evict = {
+        @CacheEvict(value = {"vets", "vetById"}, allEntries = true, cacheManager = "l1CacheManager"),
+        @CacheEvict(value = {"vets", "vetById"}, allEntries = true, cacheManager = "l2CacheManager")
+    })
     public void deleteVet(Vet vet) throws DataAccessException {
         vetRepository.delete(vet);
     }
 
     @Override
     @Transactional(readOnly = true)
+    @Caching(cacheable = {
+        @Cacheable(cacheNames = "owners", cacheManager = "l1CacheManager"),
+        @Cacheable(cacheNames = "owners", cacheManager = "l2CacheManager")
+    })
     public Collection<Owner> findAllOwners() throws DataAccessException {
         return ownerRepository.findAll();
     }
 
     @Override
     @Transactional
+    @Caching(evict = {
+        @CacheEvict(value = {"owners", "ownerById", "ownersByLastName"}, allEntries = true, cacheManager = "l1CacheManager"),
+        @CacheEvict(value = {"owners", "ownerById", "ownersByLastName"}, allEntries = true, cacheManager = "l2CacheManager")
+    })
     public void deleteOwner(Owner owner) throws DataAccessException {
         ownerRepository.delete(owner);
     }
 
     @Override
     @Transactional(readOnly = true)
+    @Caching(cacheable = {
+        @Cacheable(cacheNames = "petTypeById", key = "#petTypeId", cacheManager = "l1CacheManager"),
+        @Cacheable(cacheNames = "petTypeById", key = "#petTypeId", cacheManager = "l2CacheManager")
+    })
     public PetType findPetTypeById(int petTypeId) {
         return findEntityById(() -> petTypeRepository.findById(petTypeId));
     }
 
     @Override
     @Transactional(readOnly = true)
+    @Caching(cacheable = {
+        @Cacheable(cacheNames = "petTypes", cacheManager = "l1CacheManager"),
+        @Cacheable(cacheNames = "petTypes", cacheManager = "l2CacheManager")
+    })
     public Collection<PetType> findAllPetTypes() throws DataAccessException {
         return petTypeRepository.findAll();
     }
 
     @Override
     @Transactional
+    @Caching(evict = {
+        @CacheEvict(value = {"petTypes", "petTypeById"}, allEntries = true, cacheManager = "l1CacheManager"),
+        @CacheEvict(value = {"petTypes", "petTypeById"}, allEntries = true, cacheManager = "l2CacheManager")
+    })
     public void savePetType(PetType petType) throws DataAccessException {
         petTypeRepository.save(petType);
     }
 
     @Override
     @Transactional
+    @Caching(evict = {
+        @CacheEvict(value = {"petTypes", "petTypeById"}, allEntries = true, cacheManager = "l1CacheManager"),
+        @CacheEvict(value = {"petTypes", "petTypeById"}, allEntries = true, cacheManager = "l2CacheManager")
+    })
     public void deletePetType(PetType petType) throws DataAccessException {
         petTypeRepository.delete(petType);
     }
 
     @Override
     @Transactional(readOnly = true)
+    @Caching(cacheable = {
+        @Cacheable(cacheNames = "specialtyById", key = "#specialtyId", cacheManager = "l1CacheManager"),
+        @Cacheable(cacheNames = "specialtyById", key = "#specialtyId", cacheManager = "l2CacheManager")
+    })
     public Specialty findSpecialtyById(int specialtyId) {
         return findEntityById(() -> specialtyRepository.findById(specialtyId));
     }
 
     @Override
     @Transactional(readOnly = true)
+    @Caching(cacheable = {
+        @Cacheable(cacheNames = "specialties", cacheManager = "l1CacheManager"),
+        @Cacheable(cacheNames = "specialties", cacheManager = "l2CacheManager")
+    })
     public Collection<Specialty> findAllSpecialties() throws DataAccessException {
         return specialtyRepository.findAll();
     }
 
     @Override
     @Transactional
+    @Caching(evict = {
+        @CacheEvict(value = {"specialties", "specialtyById", "specialtiesByNameIn"}, allEntries = true, cacheManager = "l1CacheManager"),
+        @CacheEvict(value = {"specialties", "specialtyById", "specialtiesByNameIn"}, allEntries = true, cacheManager = "l2CacheManager")
+    })
     public void saveSpecialty(Specialty specialty) throws DataAccessException {
         specialtyRepository.save(specialty);
     }
 
     @Override
     @Transactional
+    @Caching(evict = {
+        @CacheEvict(value = {"specialties", "specialtyById", "specialtiesByNameIn"}, allEntries = true, cacheManager = "l1CacheManager"),
+        @CacheEvict(value = {"specialties", "specialtyById", "specialtiesByNameIn"}, allEntries = true, cacheManager = "l2CacheManager")
+    })
     public void deleteSpecialty(Specialty specialty) throws DataAccessException {
         specialtyRepository.delete(specialty);
     }
 
     @Override
     @Transactional(readOnly = true)
+    @Caching(cacheable = {
+        @Cacheable(cacheNames = "petTypes", cacheManager = "l1CacheManager"),
+        @Cacheable(cacheNames = "petTypes", cacheManager = "l2CacheManager")
+    })
     public Collection<PetType> findPetTypes() throws DataAccessException {
         return petRepository.findPetTypes();
     }
 
     @Override
     @Transactional(readOnly = true)
+    @Caching(cacheable = {
+        @Cacheable(cacheNames = "ownerById", key = "#id", cacheManager = "l1CacheManager"),
+        @Cacheable(cacheNames = "ownerById", key = "#id", cacheManager = "l2CacheManager")
+    })
     public Owner findOwnerById(int id) throws DataAccessException {
         return findEntityById(() -> ownerRepository.findById(id));
     }
 
     @Override
     @Transactional(readOnly = true)
+    @Caching(cacheable = {
+        @Cacheable(cacheNames = "petById", key = "#id", cacheManager = "l1CacheManager"),
+        @Cacheable(cacheNames = "petById", key = "#id", cacheManager = "l2CacheManager")
+    })
     public Pet findPetById(int id) throws DataAccessException {
         return findEntityById(() -> petRepository.findById(id));
     }
 
     @Override
     @Transactional
+    @Caching(evict = {
+        @CacheEvict(value = {"pets", "petById"}, allEntries = true, cacheManager = "l1CacheManager"),
+        @CacheEvict(value = {"pets", "petById"}, allEntries = true, cacheManager = "l2CacheManager")
+    })
     public void savePet(Pet pet) throws DataAccessException {
         pet.setType(findPetTypeById(pet.getType().getId()));
         petRepository.save(pet);
@@ -203,6 +298,10 @@ public class ClinicServiceImpl implements ClinicService {
 
     @Override
     @Transactional
+    @Caching(evict = {
+        @CacheEvict(value = {"visits", "visitById", "visitsByPetId"}, allEntries = true, cacheManager = "l1CacheManager"),
+        @CacheEvict(value = {"visits", "visitById", "visitsByPetId"}, allEntries = true, cacheManager = "l2CacheManager")
+    })
     public void saveVisit(Visit visit) throws DataAccessException {
         visitRepository.save(visit);
 
@@ -210,12 +309,20 @@ public class ClinicServiceImpl implements ClinicService {
 
     @Override
     @Transactional(readOnly = true)
+    @Caching(cacheable = {
+        @Cacheable(cacheNames = "vets", cacheManager = "l1CacheManager"),
+        @Cacheable(cacheNames = "vets", cacheManager = "l2CacheManager")
+    })
     public Collection<Vet> findVets() throws DataAccessException {
         return vetRepository.findAll();
     }
 
     @Override
     @Transactional
+    @Caching(evict = {
+        @CacheEvict(value = {"owners", "ownerById", "ownersByLastName"}, allEntries = true, cacheManager = "l1CacheManager"),
+        @CacheEvict(value = {"owners", "ownerById", "ownersByLastName"}, allEntries = true, cacheManager = "l2CacheManager")
+    })
     public void saveOwner(Owner owner) throws DataAccessException {
         ownerRepository.save(owner);
 
@@ -223,18 +330,30 @@ public class ClinicServiceImpl implements ClinicService {
 
     @Override
     @Transactional(readOnly = true)
+    @Caching(cacheable = {
+        @Cacheable(cacheNames = "ownersByLastName", key = "#lastName", cacheManager = "l1CacheManager"),
+        @Cacheable(cacheNames = "ownersByLastName", key = "#lastName", cacheManager = "l2CacheManager")
+    })
     public Collection<Owner> findOwnerByLastName(String lastName) throws DataAccessException {
         return ownerRepository.findByLastName(lastName);
     }
 
     @Override
     @Transactional(readOnly = true)
+    @Caching(cacheable = {
+        @Cacheable(cacheNames = "visitsByPetId", key = "#petId", cacheManager = "l1CacheManager"),
+        @Cacheable(cacheNames = "visitsByPetId", key = "#petId", cacheManager = "l2CacheManager")
+    })
     public Collection<Visit> findVisitsByPetId(int petId) {
         return visitRepository.findByPetId(petId);
     }
 
     @Override
     @Transactional(readOnly = true)
+    @Caching(cacheable = {
+        @Cacheable(cacheNames = "specialtiesByNameIn", key = "#names", cacheManager = "l1CacheManager"),
+        @Cacheable(cacheNames = "specialtiesByNameIn", key = "#names", cacheManager = "l2CacheManager")
+    })
     public List<Specialty> findSpecialtiesByNameIn(Set<String> names) {
         return findEntityById(() -> specialtyRepository.findSpecialtiesByNameIn(names));
     }

--- a/src/test/java/org/springframework/samples/petclinic/cache/HybridCacheIntegrationTest.java
+++ b/src/test/java/org/springframework/samples/petclinic/cache/HybridCacheIntegrationTest.java
@@ -1,0 +1,674 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.cache;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.cache.CacheManager;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.ResponseEntity;
+import org.springframework.samples.petclinic.model.*;
+import org.springframework.samples.petclinic.repository.*;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+/**
+ * Integration tests for hybrid caching system focusing on L1/L2 coordination and fallback scenarios.
+ * Tests cover all cached endpoints to verify hybrid cache behavior across all entity types.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Testcontainers
+@TestPropertySource(properties = {
+    "petclinic.cache.hybrid.enabled=true",
+    "petclinic.security.enable=false",
+    "spring.datasource.url=jdbc:h2:mem:hybridcachetest;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+    "spring.sql.init.schema-locations=classpath*:db/h2/schema.sql",
+    "spring.sql.init.data-locations=classpath*:db/h2/data.sql"
+})
+public class HybridCacheIntegrationTest {
+
+    @Container
+    static GenericContainer<?> redis = new GenericContainer<>(DockerImageName.parse("redis:7-alpine"))
+            .withExposedPorts(6379)
+            .withReuse(true);
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.redis.host", redis::getHost);
+        registry.add("spring.data.redis.port", () -> redis.getMappedPort(6379).toString());
+    }
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
+    @Autowired
+    @Qualifier("l1CacheManager")
+    private CacheManager cacheManager;
+
+    @MockitoBean
+    private VetRepository vetRepository;
+
+    @MockitoBean
+    private OwnerRepository ownerRepository;
+
+    @MockitoBean
+    private PetRepository petRepository;
+
+    @MockitoBean
+    private PetTypeRepository petTypeRepository;
+
+    @MockitoBean
+    private SpecialtyRepository specialtyRepository;
+
+    @MockitoBean
+    private VisitRepository visitRepository;
+
+    @MockitoBean
+    private UserRepository userRepository;
+
+    @BeforeEach
+    void setUp() {
+        clearAllCaches();
+        reset(vetRepository, ownerRepository, petRepository, petTypeRepository, specialtyRepository, visitRepository);
+        setupAllMockData();
+    }
+
+    /**
+     * Test data provider for parameterized cache tests (collection endpoints)
+     */
+    static Stream<Arguments> cacheTestData() {
+        return Stream.of(
+            Arguments.of("vets", "/api/vets", "vets", "\"id\":1", "\"id\":2"),
+            Arguments.of("owners", "/api/owners", "owners", "\"id\":1", "\"id\":2"),
+            Arguments.of("pets", "/api/pets", "pets", "\"id\":1", "\"id\":2"),
+            Arguments.of("petTypes", "/api/pettypes", "petTypes", "\"id\":1", "\"id\":2"),
+            Arguments.of("specialties", "/api/specialties", "specialties", "\"id\":1", "\"id\":2"),
+            Arguments.of("visits", "/api/visits", "visits", "\"id\":1", "\"id\":2")
+        );
+    }
+
+    /**
+     * Test data provider for parameterized cache tests (single entity endpoints)
+     */
+    static Stream<Arguments> singleEntityCacheTestData() {
+        return Stream.of(
+            Arguments.of("vets", "/api/vets/1", "vetById", "\"id\":1", "Test"),
+            Arguments.of("owners", "/api/owners/1", "ownerById", "\"id\":1", "John"),
+            Arguments.of("pets", "/api/pets/1", "petById", "\"id\":1", "Fluffy"),
+            Arguments.of("petTypes", "/api/pettypes/1", "petTypeById", "\"id\":1", "Cat"),
+            Arguments.of("specialties", "/api/specialties/1", "specialtyById", "\"id\":1", "Dentistry"),
+            Arguments.of("visits", "/api/visits/1", "visitById", "\"id\":1", "Regular checkup")
+        );
+    }
+
+    @ParameterizedTest(name = "testHybridCacheCoordination_{0}")
+    @MethodSource("cacheTestData")
+    void testHybridCacheCoordination(String entityName, String endpoint, String cacheName, String expectedId1, String expectedId2) {
+        // 1. Populate both cache layers
+        ResponseEntity<String> response1 = restTemplate.getForEntity(endpoint, String.class);
+        assertThat(response1.getStatusCode().is2xxSuccessful()).isTrue();
+
+        // 2. Verify both cache layers are populated
+        assertThat(findL1KeysForCache(cacheName)).isNotEmpty();
+        assertThat(findL2KeysForCache(cacheName)).isNotEmpty();
+
+        // 3. Verify caching is working (should be fast L1 hit)
+        clearAllRepositoryInvocations();
+        ResponseEntity<String> response2 = restTemplate.getForEntity(endpoint, String.class);
+        assertThat(response2.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(response2.getBody()).contains(expectedId1).contains(expectedId2);
+        verifyNoRepositoryInteractions();
+
+        // 4. Clear L1 cache
+        clearL1Cache();
+
+        // 5. Check L2 is working
+        clearAllRepositoryInvocations();
+        ResponseEntity<String> response3 = restTemplate.getForEntity(endpoint, String.class);
+        assertThat(response3.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(response3.getBody()).contains(expectedId1).contains(expectedId2);
+        verifyNoRepositoryInteractions();
+
+        // 6. Verify L2 is populated (L1 may or may not be full depending on implementation)
+        assertThat(findL2KeysForCache(cacheName)).isNotEmpty();
+
+        // 7. Fourth call - L1 and L2 should be populated
+        clearL2Cache();
+        ResponseEntity<String> response4 = restTemplate.getForEntity(endpoint, String.class);
+        assertThat(response4.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(response4.getBody()).contains(expectedId1).contains(expectedId2);
+
+        // 8. Check L1 is working
+        clearL2Cache();
+        clearAllRepositoryInvocations();
+        ResponseEntity<String> response5 = restTemplate.getForEntity(endpoint, String.class);
+        assertThat(response5.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(response5.getBody()).contains(expectedId1).contains(expectedId2);
+        verifyNoRepositoryInteractions();
+    }
+
+    @ParameterizedTest(name = "testCompleteCacheFallbackAndRecovery_{0}")
+    @MethodSource("cacheTestData")
+    void testCompleteCacheFallbackAndRecovery(String entityName, String endpoint, String cacheName, String expectedId1, String expectedId2) {
+        // 1. Populate both cache layers
+        ResponseEntity<String> originalResponse = restTemplate.getForEntity(endpoint, String.class);
+        assertThat(originalResponse.getStatusCode().is2xxSuccessful()).isTrue();
+
+        // 2. Verify both cache layers are populated
+        assertThat(findL1KeysForCache(cacheName)).isNotEmpty();
+        assertThat(findL2KeysForCache(cacheName)).isNotEmpty();
+
+        // 3. Verify caching is working
+        clearAllRepositoryInvocations();
+        ResponseEntity<String> cachedResponse = restTemplate.getForEntity(endpoint, String.class);
+        assertThat(cachedResponse.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(cachedResponse.getBody()).contains(expectedId1).contains(expectedId2);
+        verifyNoRepositoryInteractions();
+
+        // 4. Clear all caches completely to simulate total cache failure
+        clearAllCaches();
+        assertThat(findL1KeysForCache(cacheName)).isEmpty();
+        assertThat(findL2KeysForCache(cacheName)).isEmpty();
+
+        // 5. Call should go to database (both caches empty) and repopulate both layers
+        clearAllRepositoryInvocations();
+        ResponseEntity<String> fallbackResponse = restTemplate.getForEntity(endpoint, String.class);
+        assertThat(fallbackResponse.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(fallbackResponse.getBody()).contains(expectedId1).contains(expectedId2);
+        verifyRepositoryInteraction(entityName);
+
+        // 6. Verify both cache layers are populated
+        assertThat(findL1KeysForCache(cacheName)).isNotEmpty();
+        assertThat(findL2KeysForCache(cacheName)).isNotEmpty();
+
+        // 7. Final verification - should be cached again
+        clearAllRepositoryInvocations();
+        ResponseEntity<String> finalCachedResponse = restTemplate.getForEntity(endpoint, String.class);
+        assertThat(finalCachedResponse.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(finalCachedResponse.getBody()).contains(expectedId1).contains(expectedId2);
+        verifyNoRepositoryInteractions();
+    }
+
+    @ParameterizedTest(name = "testHybridCacheCoordination_SingleEntity_{0}")
+    @MethodSource("singleEntityCacheTestData")
+    void testHybridCacheCoordinationSingleEntity(String entityName, String endpoint, String cacheName, String expectedId, String expectedContent) {
+        // 1. Seed through REST to populate both cache layers
+        ResponseEntity<String> response1 = restTemplate.getForEntity(endpoint, String.class);
+        assertThat(response1.getStatusCode().is2xxSuccessful()).isTrue();
+
+        // 2. Verify both cache layers are populated
+        assertThat(findL1KeysForCache(cacheName)).isNotEmpty();
+        assertThat(findL2KeysForCache(cacheName)).isNotEmpty();
+
+        // 3. Verify caching is working
+        clearAllRepositoryInvocations();
+        ResponseEntity<String> response2 = restTemplate.getForEntity(endpoint, String.class);
+        assertThat(response2.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(response2.getBody()).contains(expectedId).contains(expectedContent);
+        verifyNoRepositoryInteractions();
+
+        // 4. Clear L1 cache
+        clearL1Cache();
+
+        // 5. Check L2 is working
+        clearAllRepositoryInvocations();
+        ResponseEntity<String> response3 = restTemplate.getForEntity(endpoint, String.class);
+        assertThat(response3.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(response3.getBody()).contains(expectedId).contains(expectedContent);
+        verifyNoRepositoryInteractions();
+
+        // 6. Verify L2 is populated (L1 may or may not be full depending on implementation)
+        assertThat(findL2KeysForCache(cacheName)).isNotEmpty();
+
+        // 7. Fourth call - L1 and L2 should be populated
+        clearL2Cache();
+        ResponseEntity<String> response4 = restTemplate.getForEntity(endpoint, String.class);
+        assertThat(response4.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(response4.getBody()).contains(expectedId).contains(expectedContent);
+
+        // 8. Check L1 is working
+        clearL2Cache();
+        clearAllRepositoryInvocations();
+        ResponseEntity<String> response5 = restTemplate.getForEntity(endpoint, String.class);
+        assertThat(response5.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(response5.getBody()).contains(expectedId).contains(expectedContent);
+        verifyNoRepositoryInteractions();
+    }
+
+    @ParameterizedTest(name = "testCompleteCacheFallbackAndRecovery_SingleEntity_{0}")
+    @MethodSource("singleEntityCacheTestData")
+    void testCompleteCacheFallbackAndRecoverySingleEntity(String entityName, String endpoint, String cacheName, String expectedId, String expectedContent) {
+        // 1. Load data into both caches
+        ResponseEntity<String> originalResponse = restTemplate.getForEntity(endpoint, String.class);
+        assertThat(originalResponse.getStatusCode().is2xxSuccessful()).isTrue();
+
+        // 2. Verify both cache layers are populated
+        assertThat(findL1KeysForCache(cacheName)).isNotEmpty();
+        assertThat(findL2KeysForCache(cacheName)).isNotEmpty();
+
+        // 3. Verify caching is working
+        clearAllRepositoryInvocations();
+        ResponseEntity<String> cachedResponse = restTemplate.getForEntity(endpoint, String.class);
+        assertThat(cachedResponse.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(cachedResponse.getBody()).contains(expectedId).contains(expectedContent);
+        verifyNoRepositoryInteractions();
+
+        // 4. Clear all caches completely to simulate total cache failure
+        clearAllCaches();
+        assertThat(findL1KeysForCache(cacheName)).isEmpty();
+        assertThat(findL2KeysForCache(cacheName)).isEmpty();
+
+        // 5. Call should go to database (both caches empty) and repopulate both layers
+        clearAllRepositoryInvocations();
+        ResponseEntity<String> fallbackResponse = restTemplate.getForEntity(endpoint, String.class);
+        assertThat(fallbackResponse.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(fallbackResponse.getBody()).contains(expectedId).contains(expectedContent);
+        verifySingleEntityRepositoryInteraction(entityName);
+
+        // 6. Verify both cache layers are populated
+        assertThat(findL1KeysForCache(cacheName)).isNotEmpty();
+        assertThat(findL2KeysForCache(cacheName)).isNotEmpty();
+
+        // 7. Final verification - should be cached again
+        clearAllRepositoryInvocations();
+        ResponseEntity<String> finalCachedResponse = restTemplate.getForEntity(endpoint, String.class);
+        assertThat(finalCachedResponse.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(finalCachedResponse.getBody()).contains(expectedId).contains(expectedContent);
+        verifyNoRepositoryInteractions();
+    }
+
+    @ParameterizedTest(name = "testCacheEvictAnnotation_{0}")
+    @MethodSource("cacheEvictionTestData")
+    void testCacheEvictAnnotationOnDelete(String entityName, String collectionEndpoint, String byIdEndpoint,
+                                   String deleteEndpoint, String collectionCacheName, String byIdCacheName) {
+        // Load entities into cache
+        ResponseEntity<String> entitiesBeforeDeletion = restTemplate.getForEntity(collectionEndpoint, String.class);
+        assertThat(entitiesBeforeDeletion.getStatusCode().is2xxSuccessful()).isTrue();
+
+        // Load individual entity into cache
+        ResponseEntity<String> individualEntityResponse = restTemplate.getForEntity(byIdEndpoint, String.class);
+        assertThat(individualEntityResponse.getStatusCode().is2xxSuccessful()).isTrue();
+
+        // Verify both caches are populated before deletion
+        assertThat(findL1KeysForCache(collectionCacheName)).isNotEmpty();
+        assertThat(findL2KeysForCache(collectionCacheName)).isNotEmpty();
+        assertThat(findL1KeysForCache(byIdCacheName)).isNotEmpty();
+        assertThat(findL2KeysForCache(byIdCacheName)).isNotEmpty();
+
+        // Perform DELETE request
+        restTemplate.delete(deleteEndpoint);
+
+        // Verify cache reflects deletion - both collection and by-id caches should be evicted
+        assertThat(findL1KeysForCache(collectionCacheName)).isEmpty();
+        assertThat(findL2KeysForCache(collectionCacheName)).isEmpty();
+        assertThat(findL1KeysForCache(byIdCacheName)).isEmpty();
+        assertThat(findL2KeysForCache(byIdCacheName)).isEmpty();
+    }
+
+    @ParameterizedTest(name = "testCacheEvictOnUpdate_{0}")
+    @MethodSource("cacheEvictionTestData")
+    void testCacheEvictOnUpdate(String entityName, String collectionEndpoint, String byIdEndpoint,
+                                 String deleteEndpoint, String collectionCacheName, String byIdCacheName) {
+        // Load entities into cache
+        ResponseEntity<String> collectionResponse = restTemplate.getForEntity(collectionEndpoint, String.class);
+        assertThat(collectionResponse.getStatusCode().is2xxSuccessful()).isTrue();
+
+        ResponseEntity<String> entityResponse = restTemplate.getForEntity(byIdEndpoint, String.class);
+        assertThat(entityResponse.getStatusCode().is2xxSuccessful()).isTrue();
+
+        // Verify both caches are populated before update
+        assertThat(findL1KeysForCache(collectionCacheName)).isNotEmpty();
+        assertThat(findL2KeysForCache(collectionCacheName)).isNotEmpty();
+        assertThat(findL1KeysForCache(byIdCacheName)).isNotEmpty();
+        assertThat(findL2KeysForCache(byIdCacheName)).isNotEmpty();
+
+        // Perform UPDATE (PUT) operation
+        String entityJson = entityResponse.getBody();
+        org.springframework.http.HttpHeaders headers = new org.springframework.http.HttpHeaders();
+        headers.setContentType(org.springframework.http.MediaType.APPLICATION_JSON);
+        org.springframework.http.HttpEntity<String> request = new org.springframework.http.HttpEntity<>(entityJson, headers);
+        restTemplate.exchange(byIdEndpoint, org.springframework.http.HttpMethod.PUT, request, String.class);
+
+        // Verify collection cache is evicted (except for pets which don't evict on update)
+        // byId cache may be repopulated by findById in update
+        if (!"pets".equals(entityName)) {
+            assertThat(findL1KeysForCache(collectionCacheName)).isEmpty();
+            assertThat(findL2KeysForCache(collectionCacheName)).isEmpty();
+        }
+    }
+
+    @ParameterizedTest(name = "testCacheEvictOnCreate_{0}")
+    @MethodSource("cacheEvictionOnCreateTestData")
+    void testCacheEvictOnCreate(String entityName, String collectionEndpoint, String createJson,
+                                 String collectionCacheName, String byIdCacheName) {
+        // Load entities into cache
+        ResponseEntity<String> collectionResponse = restTemplate.getForEntity(collectionEndpoint, String.class);
+        assertThat(collectionResponse.getStatusCode().is2xxSuccessful()).isTrue();
+
+        // Verify caches are populated before create
+        assertThat(findL1KeysForCache(collectionCacheName)).isNotEmpty();
+        assertThat(findL2KeysForCache(collectionCacheName)).isNotEmpty();
+
+        // Perform CREATE (POST) operation which should trigger @CacheEvict
+        org.springframework.http.HttpHeaders headers = new org.springframework.http.HttpHeaders();
+        headers.setContentType(org.springframework.http.MediaType.APPLICATION_JSON);
+        org.springframework.http.HttpEntity<String> request = new org.springframework.http.HttpEntity<>(createJson, headers);
+        restTemplate.postForEntity(collectionEndpoint, request, String.class);
+
+        // Verify both L1 and L2 caches are evicted
+        assertThat(findL1KeysForCache(collectionCacheName)).isEmpty();
+        assertThat(findL2KeysForCache(collectionCacheName)).isEmpty();
+        assertThat(findL1KeysForCache(byIdCacheName)).isEmpty();
+        assertThat(findL2KeysForCache(byIdCacheName)).isEmpty();
+    }
+
+    /**
+     * Test data provider for cache eviction tests (DELETE and UPDATE)
+     */
+    static Stream<Arguments> cacheEvictionTestData() {
+        return Stream.of(
+            Arguments.of("vets", "/api/vets", "/api/vets/1", "/api/vets/1", "vets", "vetById"),
+            Arguments.of("owners", "/api/owners", "/api/owners/1", "/api/owners/1", "owners", "ownerById"),
+            Arguments.of("pets", "/api/pets", "/api/pets/1", "/api/pets/1", "pets", "petById"),
+            Arguments.of("petTypes", "/api/pettypes", "/api/pettypes/1", "/api/pettypes/1", "petTypes", "petTypeById"),
+            Arguments.of("specialties", "/api/specialties", "/api/specialties/1", "/api/specialties/1", "specialties", "specialtyById"),
+            Arguments.of("visits", "/api/visits", "/api/visits/1", "/api/visits/1", "visits", "visitById")
+        );
+    }
+
+    /**
+     * Test data provider for cache eviction on create tests
+     */
+    static Stream<Arguments> cacheEvictionOnCreateTestData() {
+        return Stream.of(
+            Arguments.of("vets", "/api/vets",
+                "{\"firstName\":\"New\",\"lastName\":\"Vet\",\"specialties\":[]}",
+                "vets", "vetById"),
+            Arguments.of("owners", "/api/owners",
+                "{\"firstName\":\"New\",\"lastName\":\"Owner\",\"address\":\"123 St\",\"city\":\"City\",\"telephone\":\"1234567890\",\"pets\":[]}",
+                "owners", "ownerById"),
+            Arguments.of("petTypes", "/api/pettypes",
+                "{\"name\":\"NewType\"}",
+                "petTypes", "petTypeById"),
+            Arguments.of("specialties", "/api/specialties",
+                "{\"name\":\"NewSpecialty\"}",
+                "specialties", "specialtyById")
+        );
+    }
+
+    @org.junit.jupiter.api.Test
+    void testOwnerSearchByLastNameCacheDeletion() {
+        // Load parameterized cache (search by lastName)
+        ResponseEntity<String> searchResponse = restTemplate.getForEntity("/api/owners?lastName=Doe", String.class);
+        assertThat(searchResponse.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(searchResponse.getBody()).contains("\"id\":1");
+
+        // Load individual entity into cache
+        ResponseEntity<String> ownerResponse = restTemplate.getForEntity("/api/owners/1", String.class);
+        assertThat(ownerResponse.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(ownerResponse.getBody()).contains("\"id\":1");
+
+        // Verify both caches are populated before deletion
+        assertThat(findL1KeysForCache("ownersByLastName")).isNotEmpty();
+        assertThat(findL2KeysForCache("ownersByLastName")).isNotEmpty();
+        assertThat(findL1KeysForCache("ownerById")).isNotEmpty();
+        assertThat(findL2KeysForCache("ownerById")).isNotEmpty();
+
+        // Perform DELETE request
+        restTemplate.delete("/api/owners/1");
+
+        // Verify both parameterized and by-id caches are evicted after deletion
+        assertThat(findL1KeysForCache("ownersByLastName")).isEmpty();
+        assertThat(findL2KeysForCache("ownersByLastName")).isEmpty();
+        assertThat(findL1KeysForCache("ownerById")).isEmpty();
+        assertThat(findL2KeysForCache("ownerById")).isEmpty();
+    }
+
+
+    private void clearAllCaches() {
+        for (String cacheName : cacheManager.getCacheNames()) {
+            clearL1Cache(cacheName);
+            clearL2Cache(cacheName);
+        }
+    }
+
+    private void clearL1Cache(String cacheName) {
+        // Clear only L1 cache for specified cache using primary cache manager (L1)
+        org.springframework.cache.Cache cache = cacheManager.getCache(cacheName);
+        if (cache != null) {
+            cache.clear();
+        }
+    }
+
+    private void clearL2Cache(String cacheName) {
+        // Clear L2 Redis cache for specific cache name
+        Set<String> keys = redisTemplate.keys(cacheName + ":*");
+        if (keys != null && !keys.isEmpty()) {
+            redisTemplate.delete(keys);
+        }
+    }
+
+    public void clearL1Cache() {
+        // Clear all L1 cache entries
+        for (String cacheName : cacheManager.getCacheNames()) {
+            clearL1Cache(cacheName);
+        }
+    }
+
+    public void clearL2Cache() {
+        // Clear all L2 Redis cache entries
+        for (String cacheName : cacheManager.getCacheNames()) {
+            clearL2Cache(cacheName);
+        }
+    }
+
+    private Set<String> findL1KeysForCache(String cacheName) {
+        org.springframework.cache.Cache cache = cacheManager.getCache(cacheName);
+        if (cache == null) {
+            return Collections.emptySet();
+        }
+
+        // For Caffeine cache, we need to access the native cache to get keys
+        if (cache instanceof org.springframework.cache.caffeine.CaffeineCache) {
+            org.springframework.cache.caffeine.CaffeineCache caffeineCache =
+                (org.springframework.cache.caffeine.CaffeineCache) cache;
+            com.github.benmanes.caffeine.cache.Cache<Object, Object> nativeCache =
+                caffeineCache.getNativeCache();
+
+            // Convert keys to strings and return as set
+            return nativeCache.asMap().keySet().stream()
+                .map(Object::toString)
+                .collect(java.util.stream.Collectors.toSet());
+        }
+
+        // Fallback for other cache implementations
+        return Collections.emptySet();
+    }
+
+    private Set<String> findL2KeysForCache(String cacheName) {
+        Set<String> keys = redisTemplate.keys(cacheName + ":*");
+        return keys != null ? keys : Collections.emptySet();
+    }
+
+    private void clearAllRepositoryInvocations() {
+        clearInvocations(vetRepository, ownerRepository, petRepository, petTypeRepository, specialtyRepository, visitRepository);
+    }
+
+    private void verifyNoRepositoryInteractions() {
+        verifyNoInteractions(vetRepository, ownerRepository, petRepository, petTypeRepository, specialtyRepository, visitRepository);
+    }
+
+    private void verifyRepositoryInteraction(String entityName) {
+        switch (entityName) {
+            case "vets" -> verify(vetRepository).findAll();
+            case "owners" -> verify(ownerRepository).findAll();
+            case "pets" -> verify(petRepository).findAll();
+            case "petTypes" -> verify(petTypeRepository).findAll();
+            case "specialties" -> verify(specialtyRepository).findAll();
+            case "visits" -> verify(visitRepository).findAll();
+        }
+    }
+
+    private void verifySingleEntityRepositoryInteraction(String entityName) {
+        switch (entityName) {
+            case "vets" -> verify(vetRepository).findById(1);
+            case "owners" -> verify(ownerRepository).findById(1);
+            case "pets" -> verify(petRepository).findById(1);
+            case "petTypes" -> verify(petTypeRepository).findById(1);
+            case "specialties" -> verify(specialtyRepository).findById(1);
+            case "visits" -> verify(visitRepository).findById(1);
+        }
+    }
+
+    private void setupAllMockData() {
+        setupVetMockData();
+        setupOwnerMockData();
+        setupPetMockData();
+        setupPetTypeMockData();
+        setupSpecialtyMockData();
+        setupVisitMockData();
+    }
+
+    private void setupVetMockData() {
+        Vet mockVet1 = new Vet();
+        mockVet1.setId(1);
+        mockVet1.setFirstName("Test");
+        mockVet1.setLastName("Vet");
+        Vet mockVet2 = new Vet();
+        mockVet2.setId(2);
+        mockVet2.setFirstName("Another");
+        mockVet2.setLastName("Veterinarian");
+        Collection<Vet> vets = Arrays.asList(mockVet1, mockVet2);
+        when(vetRepository.findAll()).thenReturn(vets);
+        when(vetRepository.findById(1)).thenReturn(mockVet1);
+        when(vetRepository.findById(2)).thenReturn(mockVet2);
+    }
+
+    private void setupOwnerMockData() {
+        Owner mockOwner1 = new Owner();
+        mockOwner1.setId(1);
+        mockOwner1.setFirstName("John");
+        mockOwner1.setLastName("Doe");
+        mockOwner1.setAddress("123 Main St");
+        mockOwner1.setCity("Springfield");
+        mockOwner1.setTelephone("1234567890");
+
+        Owner mockOwner2 = new Owner();
+        mockOwner2.setId(2);
+        mockOwner2.setFirstName("Jane");
+        mockOwner2.setLastName("Smith");
+        mockOwner2.setAddress("456 Oak Ave");
+        mockOwner2.setCity("Springfield");
+        mockOwner2.setTelephone("0987654321");
+
+        Collection<Owner> owners = Arrays.asList(mockOwner1, mockOwner2);
+        when(ownerRepository.findAll()).thenReturn(owners);
+        when(ownerRepository.findById(1)).thenReturn(mockOwner1);
+        when(ownerRepository.findById(2)).thenReturn(mockOwner2);
+        when(ownerRepository.findByLastName("Doe")).thenReturn(Arrays.asList(mockOwner1));
+    }
+
+    private void setupPetMockData() {
+        Pet mockPet1 = new Pet();
+        mockPet1.setId(1);
+        mockPet1.setName("Fluffy");
+        mockPet1.setBirthDate(LocalDate.of(2020, 1, 1));
+
+        Pet mockPet2 = new Pet();
+        mockPet2.setId(2);
+        mockPet2.setName("Buddy");
+        mockPet2.setBirthDate(LocalDate.of(2019, 6, 15));
+
+        Collection<Pet> pets = Arrays.asList(mockPet1, mockPet2);
+        when(petRepository.findAll()).thenReturn(pets);
+        when(petRepository.findById(1)).thenReturn(mockPet1);
+        when(petRepository.findById(2)).thenReturn(mockPet2);
+    }
+
+    private void setupPetTypeMockData() {
+        PetType mockPetType1 = new PetType();
+        mockPetType1.setId(1);
+        mockPetType1.setName("Cat");
+
+        PetType mockPetType2 = new PetType();
+        mockPetType2.setId(2);
+        mockPetType2.setName("Dog");
+
+        Collection<PetType> petTypes = Arrays.asList(mockPetType1, mockPetType2);
+        when(petTypeRepository.findAll()).thenReturn(petTypes);
+        when(petTypeRepository.findById(1)).thenReturn(mockPetType1);
+        when(petTypeRepository.findById(2)).thenReturn(mockPetType2);
+    }
+
+    private void setupSpecialtyMockData() {
+        Specialty mockSpecialty1 = new Specialty();
+        mockSpecialty1.setId(1);
+        mockSpecialty1.setName("Dentistry");
+
+        Specialty mockSpecialty2 = new Specialty();
+        mockSpecialty2.setId(2);
+        mockSpecialty2.setName("Surgery");
+
+        Collection<Specialty> specialties = Arrays.asList(mockSpecialty1, mockSpecialty2);
+        when(specialtyRepository.findAll()).thenReturn(specialties);
+        when(specialtyRepository.findById(1)).thenReturn(mockSpecialty1);
+        when(specialtyRepository.findById(2)).thenReturn(mockSpecialty2);
+        when(specialtyRepository.findSpecialtiesByNameIn(Set.of("Dentistry"))).thenReturn(Arrays.asList(mockSpecialty1));
+    }
+
+    private void setupVisitMockData() {
+        Visit mockVisit1 = new Visit();
+        mockVisit1.setId(1);
+        mockVisit1.setDate(LocalDate.of(2024, 1, 15));
+        mockVisit1.setDescription("Regular checkup");
+
+        Visit mockVisit2 = new Visit();
+        mockVisit2.setId(2);
+        mockVisit2.setDate(LocalDate.of(2024, 2, 20));
+        mockVisit2.setDescription("Vaccination");
+
+        Collection<Visit> visits = Arrays.asList(mockVisit1, mockVisit2);
+        when(visitRepository.findAll()).thenReturn(visits);
+        when(visitRepository.findById(1)).thenReturn(mockVisit1);
+        when(visitRepository.findById(2)).thenReturn(mockVisit2);
+        when(visitRepository.findByPetId(1)).thenReturn(Arrays.asList(mockVisit1));
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -41,3 +41,5 @@ security.ignored=/**
 basic.authentication.enabled=true
 petclinic.security.enable=true
 
+petclinic.cache.hybrid.enabled=false
+


### PR DESCRIPTION
Task Description:
- Implement a hybrid caching strategy in the Petclinic REST API by combining local in-memory caching and distributed caching.
- Configure both cache providers and ensure service methods utilize the hybrid setup, adopting suitable patterns like read-through, write-through, or write-behind as appropriate.
- The system should ensure consistency and fallback between cache layers, providing both fast local access and reliable distributed caching.

Acceptance Criteria:
- All caching should be enabled via petclinic.cache.hybrid.enabled property. When petclinic.cache.hybrid.enabled=false, all caching is disabled - both L1 and L2 caches are not configured, and the application operates without any caching layer.
- In-memory L1 Caffeine cache configured using the following cache names: vets, vetById, owners, ownerById, ownersByLastName, pets, petById, petTypes, petTypeById, specialties, specialtyById, specialtiesByNameIn, visits, visitById, visitsByPetId.
- Redis is configured. Integration testing is performed via testcontainers.
- Hybrid caching is active for all service methods with read and write operations coordinated between cache layers
- Use named cache managers: l1CacheManager and l2CacheManager
- Cache consistency and fallback between layers is verified by tests
- Code, configuration follow project standards and all tests pass

FAIL_TO_PASS: src/test/java/org/springframework/samples/petclinic/cache/HybridCacheIntegrationTest.java