### PR TITLE
ci: add github workflow to run maven build on every PR

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,0 +1,24 @@
+name: PR Check
+
+on:
+  pull_request:
+    branches: [ "**" ]
+
+jobs:
+  verify:
+    name: Maven Build & Test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Run mvn verify
+        run: ./mvnw --no-transfer-progress verify

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/PetRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/PetRestControllerTests.java
@@ -112,7 +112,7 @@ class PetRestControllerTests {
             .andExpect(status().isOk())
             .andExpect(content().contentType("application/json"))
             .andExpect(jsonPath("$.id").value(3))
-            .andExpect(jsonPath("$.name").value("Rosy"));
+            .andExpect(jsonPath("$.name").value("Rosy the Dawg"));
     }
 
     @Test

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/PetRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/PetRestControllerTests.java
@@ -112,7 +112,7 @@ class PetRestControllerTests {
             .andExpect(status().isOk())
             .andExpect(content().contentType("application/json"))
             .andExpect(jsonPath("$.id").value(3))
-            .andExpect(jsonPath("$.name").value("Rosy the Dawg"));
+            .andExpect(jsonPath("$.name").value("Rosy"));
     }
 
     @Test


### PR DESCRIPTION
Add a simple workflow running mvn verify for every PR – simply to check the code builds correctly.

Did not touch existing workflows – there are multiple of those present, but they're not running correctly, it seems.

Copy of https://github.com/dpaia/feature-service/pull/269 

See commits below: I added broken commits to test failures – works well!
**Please squash into one commit when merging!**