### PR TITLE
fix: GET /api/session/user returns 404 after logout instead of redirecting #70

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/rest/controller/SessionController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/controller/SessionController.java
@@ -6,8 +6,10 @@ import java.util.stream.Collectors;
 
 import jakarta.servlet.http.HttpSession;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.samples.petclinic.security.OAuth2AuthenticationSuccessHandler;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -28,6 +30,7 @@ public class SessionController {
     private static final String RESERVED_KEY = OAuth2AuthenticationSuccessHandler.SESSION_KEY_AUTHENTICATED_USER;
 
     @GetMapping("/user")
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<Map<String, Object>> getUser(HttpSession session, Authentication authentication) {
         @SuppressWarnings("unchecked")
         Map<String, Object> userInfo = (Map<String, Object>) session.getAttribute(RESERVED_KEY);
@@ -40,7 +43,7 @@ public class SessionController {
         }
 
         if (userInfo == null) {
-            return ResponseEntity.notFound().build();
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
         return ResponseEntity.ok(userInfo);
     }

--- a/src/main/java/org/springframework/samples/petclinic/security/OAuth2SecurityConfig.java
+++ b/src/main/java/org/springframework/samples/petclinic/security/OAuth2SecurityConfig.java
@@ -49,7 +49,7 @@ public class OAuth2SecurityConfig {
             )
             .exceptionHandling(ex -> ex
                 .authenticationEntryPoint((request, response, authException) ->
-                    response.sendRedirect("/oauth2/authorization/" + provider)
+                    response.sendRedirect(request.getContextPath() + "/oauth2/authorization/" + provider)
                 )
             );
         return http.build();

--- a/src/test/java/org/springframework/samples/petclinic/OAuth2IntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/OAuth2IntegrationTests.java
@@ -140,6 +140,28 @@ class OAuth2IntegrationTests {
     }
 
     @Test
+    void testGetSessionUserAfterLogout() throws Exception {
+        MockHttpSession session = new MockHttpSession();
+
+        // 1. Authenticate first to establish a session
+        mockMvc.perform(get("/api/session/user")
+                .with(oauth2Login())
+                .session(session))
+            .andExpect(status().isOk());
+
+        // 2. Logout with that session
+        mockMvc.perform(post("/api/auth/logout")
+                .session(session))
+            .andExpect(status().isOk());
+
+        // 3. Immediately call GET /api/session/user again with the now-invalidated session
+        // It should redirect (302) to the OAuth2 login page, NOT return 404
+        mockMvc.perform(get("/api/session/user")
+                .session(session))
+            .andExpect(status().is3xxRedirection());
+    }
+
+    @Test
     void testSessionPersistenceAcrossRequests() throws Exception {
         MockHttpSession session = new MockHttpSession();
 


### PR DESCRIPTION
Bug fix for #70 

FAIL_TO_PASS: OAuth2IntegrationTests#testGetSessionUserAfterLogout