### PR TITLE
Implement GET endpoint to find all users

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,9 @@
   "jvm_version": "21",
   "build_system": "maven",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "org.springframework.samples.petclinic.rest.controller.UserRestControllerTests#testGetAllUsers"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/src/main/java/org/springframework/samples/petclinic/repository/UserRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/UserRepository.java
@@ -3,7 +3,11 @@ package org.springframework.samples.petclinic.repository;
 import org.springframework.dao.DataAccessException;
 import org.springframework.samples.petclinic.model.User;
 
+import java.util.Collection;
+
 public interface UserRepository {
 
     void save(User user) throws DataAccessException;
+
+    Collection<User> findAll() throws DataAccessException;
 }

--- a/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcUserRepositoryImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jdbc/JdbcUserRepositoryImpl.java
@@ -1,5 +1,6 @@
 package org.springframework.samples.petclinic.repository.jdbc;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -64,5 +65,13 @@ public class JdbcUserRepositoryImpl implements UserRepository {
                 this.namedParameterJdbcTemplate.update("INSERT INTO roles(username, role) VALUES (:username, :role)", params);
             }
         }
+    }
+
+    @Override
+    public Collection<User> findAll() throws DataAccessException {
+        return this.namedParameterJdbcTemplate.query(
+            "SELECT * FROM users",
+            BeanPropertyRowMapper.newInstance(User.class)
+        );
     }
 }

--- a/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaUserRepositoryImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaUserRepositoryImpl.java
@@ -2,12 +2,15 @@ package org.springframework.samples.petclinic.repository.jpa;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Query;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.dao.DataAccessException;
 import org.springframework.samples.petclinic.model.User;
 import org.springframework.samples.petclinic.repository.UserRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.Collection;
 
 @Repository
 @Profile("jpa")
@@ -23,5 +26,11 @@ public class JpaUserRepositoryImpl implements UserRepository {
         } else {
             this.em.merge(user);
         }
+    }
+
+    @Override
+    public Collection<User> findAll() throws DataAccessException {
+        Query query = this.em.createQuery("SELECT user FROM User user");
+        return query.getResultList();
     }
 }

--- a/src/main/java/org/springframework/samples/petclinic/rest/controller/UserRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/controller/UserRestController.java
@@ -31,6 +31,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.Valid;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @CrossOrigin(exposedHeaders = "errors, content-type")
@@ -53,5 +57,15 @@ public class UserRestController implements UsersApi {
         User user = userMapper.toUser(userDto);
         this.userService.saveUser(user);
         return new ResponseEntity<>(userMapper.toUserDto(user), headers, HttpStatus.CREATED);
+    }
+
+    @PreAuthorize( "hasRole(@roles.ADMIN)" )
+    @Override
+    public ResponseEntity<List<UserDto>> listUsers() {
+        Collection<User> users = this.userService.findAllUsers();
+        List<UserDto> userDtos = users.stream()
+            .map(userMapper::toUserDto)
+            .collect(Collectors.toList());
+        return new ResponseEntity<>(userDtos, HttpStatus.OK);
     }
 }

--- a/src/main/java/org/springframework/samples/petclinic/service/UserService.java
+++ b/src/main/java/org/springframework/samples/petclinic/service/UserService.java
@@ -2,7 +2,11 @@ package org.springframework.samples.petclinic.service;
 
 import org.springframework.samples.petclinic.model.User;
 
+import java.util.Collection;
+
 public interface UserService {
 
-    void saveUser(User user) ;
+    void saveUser(User user);
+
+    Collection<User> findAllUsers();
 }

--- a/src/main/java/org/springframework/samples/petclinic/service/UserServiceImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/service/UserServiceImpl.java
@@ -7,6 +7,8 @@ import org.springframework.samples.petclinic.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collection;
+
 @Service
 public class UserServiceImpl implements UserService {
 
@@ -32,5 +34,11 @@ public class UserServiceImpl implements UserService {
         }
 
         userRepository.save(user);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Collection<User> findAllUsers() {
+        return userRepository.findAll();
     }
 }

--- a/src/main/resources/openapi.yml
+++ b/src/main/resources/openapi.yml
@@ -1770,6 +1770,39 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProblemDetail'
+    get:
+      tags:
+        - user
+      operationId: listUsers
+      summary: Lists users
+      description: Returns an array of users.
+      responses:
+        200:
+          description: User details found and returned.
+          headers:
+            ETag:
+              description: An ID for this version of the response.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/User'
+        304:
+          description: Not modified.
+          headers:
+            ETag:
+              description: An ID for this version of the response.
+              schema:
+                type: string
+        500:
+          description: Server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
 components:
   schemas:
     ProblemDetail:

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/UserRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/UserRestControllerTests.java
@@ -10,7 +10,6 @@ import org.springframework.http.MediaType;
 import org.springframework.samples.petclinic.mapper.UserMapper;
 import org.springframework.samples.petclinic.model.User;
 import org.springframework.samples.petclinic.rest.advice.ExceptionControllerAdvice;
-import org.springframework.samples.petclinic.rest.controller.UserRestController;
 import org.springframework.samples.petclinic.service.UserService;
 import org.springframework.samples.petclinic.service.clinicService.ApplicationTestConfig;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -19,8 +18,9 @@ import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest
 @ContextConfiguration(classes = ApplicationTestConfig.class)
@@ -71,5 +71,15 @@ class UserRestControllerTests {
         this.mockMvc.perform(post("/api/users")
             .content(newVetAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void testGetAllUsers() throws Exception {
+        this.mockMvc.perform(get("/api/users")
+            .accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType("application/json"))
+            .andExpect(jsonPath("$.[0].username").value("admin"));
     }
 }


### PR DESCRIPTION
Implement GET endpoint to find all users

- Add 'GET /api/users' endpoint returning user list
- Secure with admin role authorization  
- Implement across all layers:
  - Repository: 'findAll()' for JDBC and JPA
  - Service: 'findAllUsers()' with read-only transaction
  - Controller: return 'List<UserDto>' with 200 status
- Update OpenAPI documentation
- Use existing UserMapper for DTO conversion