### PR TITLE
Exception handling

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,9 @@
   "jvm_version": "21",
   "build_system": "maven",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "org.springframework.samples.petclinic.rest.advice.ExceptionControllerAdviceTests"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -6,7 +6,11 @@
   "build_system": "maven",
   "expected": {
     "fail_to_pass": [
-      "org.springframework.samples.petclinic.rest.advice.ExceptionControllerAdviceTests"
+      "org.springframework.samples.petclinic.rest.advice.ExceptionControllerAdviceTests.testHandleAccessDeniedException",
+      "org.springframework.samples.petclinic.rest.advice.ExceptionControllerAdviceTests.testHandleHttpMessageNotReadableException",
+      "org.springframework.samples.petclinic.rest.advice.ExceptionControllerAdviceTests.testHandleHttpRequestMethodNotSupportedException",
+      "org.springframework.samples.petclinic.rest.advice.ExceptionControllerAdviceTests.testHandleMethodArgumentTypeMismatchException",
+      "org.springframework.samples.petclinic.rest.advice.ExceptionControllerAdviceTests.testHandleNoResourceFoundException"
     ],
     "pass_to_pass": []
   },

--- a/src/main/java/org/springframework/samples/petclinic/rest/advice/ExceptionControllerAdvice.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/advice/ExceptionControllerAdvice.java
@@ -21,12 +21,18 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.samples.petclinic.rest.controller.BindingErrorsResponse;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import java.net.URI;
 import java.time.Instant;
@@ -113,4 +119,88 @@ public class ExceptionControllerAdvice {
         return ResponseEntity.status(status).build();
     }
 
+    /**
+     * Handles {@link HttpMessageNotReadableException} which occurs when the request body is malformed or
+     * cannot be deserialized into the required object.
+     *
+     * @param ex The {@link HttpMessageNotReadableException} to be handled
+     * @param request {@link HttpServletRequest} object referring to the current request.
+     * @return A {@link ResponseEntity} containing the error information and a 400 Bad Request status
+     */
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    @ResponseBody
+    public ResponseEntity<ProblemDetail> handleHttpMessageNotReadableException(HttpMessageNotReadableException ex, HttpServletRequest request) {
+        HttpStatus status = HttpStatus.BAD_REQUEST;
+        ProblemDetail detail = this.detailBuild(ex, status, request.getRequestURL());
+        detail.setDetail("Malformed JSON request: " + ex.getLocalizedMessage());
+        return ResponseEntity.status(status).body(detail);
+    }
+
+    /**
+     * Handles {@link MethodArgumentTypeMismatchException} which occurs when a method argument is not
+     * the expected type.
+     *
+     * @param ex The {@link MethodArgumentTypeMismatchException} to be handled
+     * @param request {@link HttpServletRequest} object referring to the current request.
+     * @return A {@link ResponseEntity} containing the error information and a 400 Bad Request status
+     */
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    @ResponseBody
+    public ResponseEntity<ProblemDetail> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException ex, HttpServletRequest request) {
+        HttpStatus status = HttpStatus.BAD_REQUEST;
+        ProblemDetail detail = this.detailBuild(ex, status, request.getRequestURL());
+        detail.setDetail("Type mismatch for parameter '" + ex.getName() + "': " + ex.getLocalizedMessage());
+        return ResponseEntity.status(status).body(detail);
+    }
+
+    /**
+     * Handles {@link NoHandlerFoundException} and {@link NoResourceFoundException} which occur when
+     * a requested resource is not found.
+     *
+     * @param ex The exception to be handled
+     * @param request {@link HttpServletRequest} object referring to the current request.
+     * @return A {@link ResponseEntity} containing the error information and a 404 Not Found status
+     */
+    @ExceptionHandler({NoHandlerFoundException.class, NoResourceFoundException.class})
+    @ResponseBody
+    public ResponseEntity<ProblemDetail> handleResourceNotFoundException(Exception ex, HttpServletRequest request) {
+        HttpStatus status = HttpStatus.NOT_FOUND;
+        ProblemDetail detail = this.detailBuild(ex, status, request.getRequestURL());
+        detail.setDetail("The requested resource was not found: " + request.getRequestURI());
+        return ResponseEntity.status(status).body(detail);
+    }
+
+    /**
+     * Handles {@link AccessDeniedException} which occurs when a user does not have permission to
+     * access a resource.
+     *
+     * @param ex The {@link AccessDeniedException} to be handled
+     * @param request {@link HttpServletRequest} object referring to the current request.
+     * @return A {@link ResponseEntity} containing the error information and a 403 Forbidden status
+     */
+    @ExceptionHandler(AccessDeniedException.class)
+    @ResponseBody
+    public ResponseEntity<ProblemDetail> handleAccessDeniedException(AccessDeniedException ex, HttpServletRequest request) {
+        HttpStatus status = HttpStatus.FORBIDDEN;
+        ProblemDetail detail = this.detailBuild(ex, status, request.getRequestURL());
+        detail.setDetail("Access denied: " + ex.getLocalizedMessage());
+        return ResponseEntity.status(status).body(detail);
+    }
+
+    /**
+     * Handles {@link HttpRequestMethodNotSupportedException} which occurs when a request is made with
+     * an unsupported HTTP method.
+     *
+     * @param ex The {@link HttpRequestMethodNotSupportedException} to be handled
+     * @param request {@link HttpServletRequest} object referring to the current request.
+     * @return A {@link ResponseEntity} containing the error information and a 405 Method Not Allowed status
+     */
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    @ResponseBody
+    public ResponseEntity<ProblemDetail> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException ex, HttpServletRequest request) {
+        HttpStatus status = HttpStatus.METHOD_NOT_ALLOWED;
+        ProblemDetail detail = this.detailBuild(ex, status, request.getRequestURL());
+        detail.setDetail("Method not allowed: " + ex.getMethod() + ". Supported methods are: " + String.join(", ", ex.getSupportedMethods()));
+        return ResponseEntity.status(status).body(detail);
+    }
 }

--- a/src/test/java/org/springframework/samples/petclinic/rest/advice/ExceptionControllerAdviceTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/advice/ExceptionControllerAdviceTests.java
@@ -1,0 +1,196 @@
+package org.springframework.samples.petclinic.rest.advice;
+
+/**
+ * Tests for the ExceptionControllerAdvice class.
+ *
+ * This test class verifies that the global exception handling mechanism correctly handles
+ * various types of exceptions that can occur in the application and returns appropriate
+ * HTTP responses with problem details.
+ *
+ * Exception types tested:
+ * - General exceptions (RuntimeException) - 500 Internal Server Error
+ * - Data integrity violations (DataIntegrityViolationException) - 404 Not Found
+ * - Validation errors (MethodArgumentNotValidException) - 400 Bad Request
+ * - Malformed request bodies (HttpMessageNotReadableException) - 400 Bad Request
+ * - Type mismatches (MethodArgumentTypeMismatchException) - 400 Bad Request
+ * - Resource not found (NoResourceFoundException) - 404 Not Found
+ * - Access denied (AccessDeniedException) - 403 Forbidden
+ * - Unsupported HTTP methods (HttpRequestMethodNotSupportedException) - 405 Method Not Allowed
+ *
+ * Each test verifies:
+ * 1. The correct HTTP status code is returned
+ * 2. The response contains appropriate error details in the ProblemDetail format
+ * 3. The exception type is correctly identified in the response
+ */
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.samples.petclinic.service.clinicService.ApplicationTestConfig;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.*;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ContextConfiguration(classes = ApplicationTestConfig.class)
+@WebAppConfiguration
+class ExceptionControllerAdviceTests {
+
+    private MockMvc mockMvc;
+
+    // Test controller that will throw various exceptions
+    @RestController
+    @RequestMapping("/test")
+    static class TestController {
+
+        @GetMapping("/general-exception")
+        public ResponseEntity<String> throwGeneralException() {
+            throw new RuntimeException("General error");
+        }
+
+        @GetMapping("/data-integrity")
+        public ResponseEntity<String> throwDataIntegrityViolationException() {
+            throw new DataIntegrityViolationException("Data integrity violation");
+        }
+
+        @PostMapping("/validation")
+        public ResponseEntity<String> validateRequest(@Valid @RequestBody TestDto dto) {
+            return ResponseEntity.ok("Valid");
+        }
+
+        @GetMapping("/type-mismatch/{id}")
+        public ResponseEntity<String> getWithTypeParameter(@PathVariable("id") Integer id) {
+            return ResponseEntity.ok("ID: " + id);
+        }
+
+        @GetMapping("/access-denied")
+        public ResponseEntity<String> throwAccessDeniedException() {
+            throw new AccessDeniedException("Access denied");
+        }
+
+        // This endpoint only supports GET
+        @GetMapping("/method-not-allowed")
+        public ResponseEntity<String> methodNotAllowed() {
+            return ResponseEntity.ok("GET supported");
+        }
+    }
+
+    // Simple DTO for validation tests
+    static class TestDto {
+        @NotBlank
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    @BeforeEach
+    void setup() {
+        this.mockMvc = MockMvcBuilders.standaloneSetup(new TestController())
+            .setControllerAdvice(new ExceptionControllerAdvice())
+            .build();
+    }
+
+    @Test
+    void testHandleGeneralException() throws Exception {
+        mockMvc.perform(get("/test/general-exception")
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isInternalServerError())
+            .andExpect(jsonPath("$.title").value("RuntimeException"))
+            .andExpect(jsonPath("$.detail").value("General error"));
+    }
+
+    @Test
+    void testHandleDataIntegrityViolationException() throws Exception {
+        mockMvc.perform(get("/test/data-integrity")
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.title").value("DataIntegrityViolationException"))
+            .andExpect(jsonPath("$.detail").value("Data integrity violation"));
+    }
+
+    @Test
+    void testHandleMethodArgumentNotValidException() throws Exception {
+        // This exception is typically thrown during validation of request bodies
+        // We'll test it by sending an invalid request body to a controller endpoint
+        String invalidJson = "{\"name\":\"\"}"; // Empty name which should fail validation
+
+        mockMvc.perform(post("/test/validation")
+                .content(invalidJson)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.title").value("MethodArgumentNotValidException"));
+    }
+
+    @Test
+    void testHandleHttpMessageNotReadableException() throws Exception {
+        // Send malformed JSON to trigger HttpMessageNotReadableException
+        String malformedJson = "{\"name\":}"; // Missing value after colon
+
+        mockMvc.perform(post("/test/validation")
+                .content(malformedJson)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.title").value("HttpMessageNotReadableException"))
+            .andExpect(jsonPath("$.detail").exists());
+    }
+
+    @Test
+    void testHandleMethodArgumentTypeMismatchException() throws Exception {
+        // Using a string where an integer is expected should trigger MethodArgumentTypeMismatchException
+        mockMvc.perform(get("/test/type-mismatch/abc") // 'abc' is not a valid integer ID
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.title").value("MethodArgumentTypeMismatchException"))
+            .andExpect(jsonPath("$.detail").exists());
+    }
+
+    @Test
+    void testHandleAccessDeniedException() throws Exception {
+        mockMvc.perform(get("/test/access-denied")
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.title").value("AccessDeniedException"))
+            .andExpect(jsonPath("$.detail").value("Access denied: Access denied"));
+    }
+
+    @Test
+    void testHandleHttpRequestMethodNotSupportedException() throws Exception {
+        // Try to DELETE a resource that only supports GET
+        mockMvc.perform(delete("/test/method-not-allowed")
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isMethodNotAllowed())
+            .andExpect(jsonPath("$.title").value("HttpRequestMethodNotSupportedException"))
+            .andExpect(jsonPath("$.detail").exists());
+    }
+
+    @Test
+    void testHandleNoResourceFoundException() throws Exception {
+        // Request a non-existent resource
+        mockMvc.perform(get("/test/non-existent-path")
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound());
+    }
+}


### PR DESCRIPTION
Enhance the global exception handling in ExceptionControllerAdvice by adding handlers for the following exceptions with the specified HTTP status codes:
  - HttpMessageNotReadableException → 400 Bad Request
  - MethodArgumentTypeMismatchException → 400 Bad Request
  - AccessDeniedException → 403 Forbidden
  - HttpRequestMethodNotSupportedException → 405 Method Not Allowed
  - NoHandlerFoundException and NoResourceFoundException → 404 Not Found

Each handler must return a ProblemDetail containing the HTTP status, a meaningful title, a descriptive detail message, and the request path. Unit tests must verify the correct status codes and the content of ProblemDetail. All handlers should use @ExceptionHandler and @ResponseBody