### PR TITLE
Implement a custom authentication provider that delegates authentication to an external SSO API

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -6,7 +6,10 @@
   "build_system": "maven",
   "expected": {
     "fail_to_pass": [
-      "org.springframework.samples.petclinic.security.sso.SsoAuthenticationTest"
+      "org.springframework.samples.petclinic.security.sso.SsoAuthenticationTest.testSuccessfulSsoAuthentication",
+      "org.springframework.samples.petclinic.security.sso.SsoAuthenticationTest.testRoleMapping",
+      "org.springframework.samples.petclinic.security.sso.SsoAuthenticationTest.testRoleMappingWithoutRolePrefix",
+      "org.springframework.samples.petclinic.security.sso.SsoAuthenticationTest.testSsoServiceUnavailable"
     ],
     "pass_to_pass": []
   },

--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,9 @@
   "jvm_version": "21",
   "build_system": "maven",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "org.springframework.samples.petclinic.security.sso.SsoAuthenticationTest"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/src/main/java/org/springframework/samples/petclinic/security/BasicAuthenticationConfig.java
+++ b/src/main/java/org/springframework/samples/petclinic/security/BasicAuthenticationConfig.java
@@ -9,11 +9,13 @@ import org.springframework.security.config.annotation.authentication.builders.Au
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.DelegatingPasswordEncoder;
 import org.springframework.security.crypto.password.NoOpPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.samples.petclinic.security.sso.SsoAuthenticationProvider;
 
 import javax.sql.DataSource;
 import java.util.Map;
@@ -31,8 +33,6 @@ public class BasicAuthenticationConfig {
         return new BCryptPasswordEncoder();
     }
 
-
-
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         // @formatter:off
@@ -46,13 +46,8 @@ public class BasicAuthenticationConfig {
     }
 
     @Autowired
-    public void configureGlobal(AuthenticationManagerBuilder auth) throws Exception {
-        // @formatter:off
-        auth
-            .jdbcAuthentication()
-                .dataSource(dataSource)
-                .usersByUsernameQuery("select username,password,enabled from users where username=?")
-                .authoritiesByUsernameQuery("select username,role from roles where username=?");
-        // @formatter:on
+    public void configureGlobal(AuthenticationManagerBuilder auth, SsoAuthenticationProvider ssoAuthenticationProvider) throws Exception {
+        // Register SSO Authentication Provider first (primary authentication method)
+        auth.authenticationProvider(ssoAuthenticationProvider);
     }
 }

--- a/src/main/java/org/springframework/samples/petclinic/security/BasicAuthenticationConfig.java
+++ b/src/main/java/org/springframework/samples/petclinic/security/BasicAuthenticationConfig.java
@@ -1,6 +1,7 @@
 package org.springframework.samples.petclinic.security;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -9,7 +10,6 @@ import org.springframework.security.config.annotation.authentication.builders.Au
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.DelegatingPasswordEncoder;
 import org.springframework.security.crypto.password.NoOpPasswordEncoder;
@@ -46,8 +46,16 @@ public class BasicAuthenticationConfig {
     }
 
     @Autowired
-    public void configureGlobal(AuthenticationManagerBuilder auth, SsoAuthenticationProvider ssoAuthenticationProvider) throws Exception {
-        // Register SSO Authentication Provider first (primary authentication method)
-        auth.authenticationProvider(ssoAuthenticationProvider);
+    public void configureGlobal(AuthenticationManagerBuilder auth,
+                                ObjectProvider<SsoAuthenticationProvider> ssoAuthenticationProvider) throws Exception {
+        ssoAuthenticationProvider.ifAvailable(auth::authenticationProvider);
+
+        // @formatter:off
+        auth
+            .jdbcAuthentication()
+                .dataSource(dataSource)
+                .usersByUsernameQuery("select username,password,enabled from users where username=?")
+                .authoritiesByUsernameQuery("select username,role from roles where username=?");
+        // @formatter:on
     }
 }

--- a/src/main/java/org/springframework/samples/petclinic/security/sso/SsoAuthenticationException.java
+++ b/src/main/java/org/springframework/samples/petclinic/security/sso/SsoAuthenticationException.java
@@ -1,0 +1,14 @@
+package org.springframework.samples.petclinic.security.sso;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class SsoAuthenticationException extends AuthenticationException {
+
+    public SsoAuthenticationException(String msg) {
+        super(msg);
+    }
+
+    public SsoAuthenticationException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+}

--- a/src/main/java/org/springframework/samples/petclinic/security/sso/SsoAuthenticationProvider.java
+++ b/src/main/java/org/springframework/samples/petclinic/security/sso/SsoAuthenticationProvider.java
@@ -1,0 +1,78 @@
+package org.springframework.samples.petclinic.security.sso;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class SsoAuthenticationProvider implements AuthenticationProvider {
+
+    private static final Logger logger = LoggerFactory.getLogger(SsoAuthenticationProvider.class);
+
+    private final SsoService ssoService;
+
+    public SsoAuthenticationProvider(SsoService ssoService) {
+        this.ssoService = ssoService;
+    }
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        String username = authentication.getName();
+        String password = authentication.getCredentials().toString();
+
+        try {
+            // Try to authenticate with SSO
+            logger.debug("Attempting SSO authentication for user: {}", username);
+            SsoAuthenticationResult ssoResult = ssoService.authenticate(username, password);
+
+            if (ssoResult.authenticated()) {
+                List<GrantedAuthority> authorities = mapExternalRolesToAuthorities(ssoResult.roles());
+                return new UsernamePasswordAuthenticationToken(
+                    username, password, authorities);
+            } else {
+                throw new BadCredentialsException("SSO authentication failed");
+            }
+        } catch (BadCredentialsException e) {
+            throw e;
+        }
+        catch (SsoAuthenticationException e) {
+            // SSO service unavailable or other SSO-specific error
+            logger.warn("SSO authentication failed, falling back to local authentication: {}", e.getMessage());
+            throw new AuthenticationServiceException("SSO authentication failed", e);
+        } catch (Exception e) {
+            logger.error("Unexpected error during SSO authentication", e);
+            throw new AuthenticationServiceException("Authentication failed due to an internal error", e);
+        }
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return authentication.equals(UsernamePasswordAuthenticationToken.class);
+    }
+
+    private List<GrantedAuthority> mapExternalRolesToAuthorities(List<String> externalRoles) {
+        List<GrantedAuthority> authorities = new ArrayList<>();
+
+        for (String role : externalRoles) {
+            // Map external roles to Spring Security roles
+            // Example: If external role is "ADMIN", map to "ROLE_ADMIN"
+            if (!role.startsWith("ROLE_")) {
+                role = "ROLE_" + role.toUpperCase();
+            }
+            authorities.add(new SimpleGrantedAuthority(role));
+        }
+
+        return authorities;
+    }
+}

--- a/src/main/java/org/springframework/samples/petclinic/security/sso/SsoAuthenticationProvider.java
+++ b/src/main/java/org/springframework/samples/petclinic/security/sso/SsoAuthenticationProvider.java
@@ -2,9 +2,11 @@ package org.springframework.samples.petclinic.security.sso;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
@@ -16,6 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Component
+@ConditionalOnProperty(name = {"petclinic.security.enable", "petclinic.security.sso.enabled"}, havingValue = "true")
 public class SsoAuthenticationProvider implements AuthenticationProvider {
 
     private static final Logger logger = LoggerFactory.getLogger(SsoAuthenticationProvider.class);
@@ -47,9 +50,8 @@ public class SsoAuthenticationProvider implements AuthenticationProvider {
             throw e;
         }
         catch (SsoAuthenticationException e) {
-            // SSO service unavailable or other SSO-specific error
-            logger.warn("SSO authentication failed, falling back to local authentication: {}", e.getMessage());
-            throw new AuthenticationServiceException("SSO authentication failed", e);
+            logger.warn("SSO authentication failed: {}", e.getMessage());
+            throw new InternalAuthenticationServiceException("SSO authentication failed", e);
         } catch (Exception e) {
             logger.error("Unexpected error during SSO authentication", e);
             throw new AuthenticationServiceException("Authentication failed due to an internal error", e);

--- a/src/main/java/org/springframework/samples/petclinic/security/sso/SsoAuthenticationResult.java
+++ b/src/main/java/org/springframework/samples/petclinic/security/sso/SsoAuthenticationResult.java
@@ -1,0 +1,5 @@
+package org.springframework.samples.petclinic.security.sso;
+
+import java.util.List;
+
+public record SsoAuthenticationResult(boolean authenticated, List<String> roles){}

--- a/src/main/java/org/springframework/samples/petclinic/security/sso/SsoService.java
+++ b/src/main/java/org/springframework/samples/petclinic/security/sso/SsoService.java
@@ -1,0 +1,86 @@
+package org.springframework.samples.petclinic.security.sso;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class SsoService {
+
+    private static final Logger logger = LoggerFactory.getLogger(SsoService.class);
+
+    @Value("${petclinic.security.sso.url}")
+    private String ssoApiUrl;
+
+    private final RestTemplate restTemplate;
+
+    public SsoService(RestTemplateBuilder restTemplateBuilder,
+                      @Value("${petclinic.security.sso.timeout:5000}") int ssoTimeout) {
+        this.restTemplate = restTemplateBuilder
+            .connectTimeout(Duration.ofMillis(ssoTimeout))
+            .readTimeout(Duration.ofMillis(ssoTimeout))
+            .build();
+    }
+
+    /**
+     * Authenticate a user using the external SSO service
+     *
+     * @param username The username
+     * @param password The password
+     * @return SsoAuthenticationResult containing authentication status and roles
+     * @throws SsoAuthenticationException if SSO service is unavailable or returns an error
+     */
+    public SsoAuthenticationResult authenticate(String username, String password) throws SsoAuthenticationException {
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setBasicAuth(username, password);
+
+            HttpEntity<String> entity = new HttpEntity<>(headers);
+
+            ResponseEntity<Map> response = restTemplate.exchange(
+                ssoApiUrl,
+                HttpMethod.POST,
+                entity,
+                Map.class
+            );
+
+            if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
+                Map<String, Object> responseBody = response.getBody();
+                boolean authenticated = (boolean) responseBody.getOrDefault("authenticated", false);
+
+                if (authenticated) {
+                    @SuppressWarnings("unchecked")
+                    List<String> roles = (List<String>) responseBody.getOrDefault("roles", new ArrayList<>());
+                    return new SsoAuthenticationResult(true, roles);
+                }
+            }
+
+            return new SsoAuthenticationResult(false, new ArrayList<>());
+
+        } catch (RestClientException e) {
+            if (e instanceof HttpClientErrorException.Unauthorized){
+                logger.error("Unauthorized by SSO service", e);
+                return new SsoAuthenticationResult(false, new ArrayList<>());
+            }
+            logger.error("SSO service unavailable or returned an error", e);
+            throw new SsoAuthenticationException("SSO service unavailable", e);
+        } catch (Exception e) {
+            logger.error("Unexpected error during SSO authentication", e);
+            throw new SsoAuthenticationException("Error during SSO authentication", e);
+        }
+    }
+}

--- a/src/main/java/org/springframework/samples/petclinic/security/sso/SsoService.java
+++ b/src/main/java/org/springframework/samples/petclinic/security/sso/SsoService.java
@@ -3,6 +3,7 @@ package org.springframework.samples.petclinic.security.sso;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -19,17 +20,18 @@ import java.util.List;
 import java.util.Map;
 
 @Service
+@ConditionalOnProperty(name = {"petclinic.security.enable", "petclinic.security.sso.enabled"}, havingValue = "true")
 public class SsoService {
 
     private static final Logger logger = LoggerFactory.getLogger(SsoService.class);
 
-    @Value("${petclinic.security.sso.url}")
-    private String ssoApiUrl;
-
+    private final String ssoApiUrl;
     private final RestTemplate restTemplate;
 
     public SsoService(RestTemplateBuilder restTemplateBuilder,
+                      @Value("${petclinic.security.sso.url}") String ssoApiUrl,
                       @Value("${petclinic.security.sso.timeout:5000}") int ssoTimeout) {
+        this.ssoApiUrl = ssoApiUrl;
         this.restTemplate = restTemplateBuilder
             .connectTimeout(Duration.ofMillis(ssoTimeout))
             .readTimeout(Duration.ofMillis(ssoTimeout))

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -30,7 +30,10 @@ database=h2
 spring.sql.init.mode=always  
 spring.sql.init.schema-locations=classpath*:db/${database}/schema.sql
 spring.sql.init.data-locations=classpath*:db/${database}/data.sql
-
+# SSO Configuration
+petclinic.security.sso.url=https://sso-api.example.com/auth
+petclinic.security.sso.timeout=5000
+petclinic.security.sso.enabled=true
 spring.messages.basename=messages/messages
 spring.jpa.open-in-view=false
 

--- a/src/test/java/org/springframework/samples/petclinic/security/sso/SsoAuthenticationTest.java
+++ b/src/test/java/org/springframework/samples/petclinic/security/sso/SsoAuthenticationTest.java
@@ -1,0 +1,204 @@
+package org.springframework.samples.petclinic.security.sso;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.samples.petclinic.service.clinicService.ApplicationTestConfig;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@ContextConfiguration(classes = ApplicationTestConfig.class)
+@Import({SsoAuthenticationTest.MockSsoControllerTestConfig.class, SsoAuthenticationTest.MockSsoController.class})
+@TestPropertySource(properties = {
+    "petclinic.security.sso.url=http://localhost:8087/petclinic/mock-sso/auth",
+    "server.port=8087",
+    "petclinic.security.enable=true"
+})
+public class SsoAuthenticationTest {
+
+    @Autowired
+    private AuthenticationConfiguration authConfig;
+
+    private AuthenticationManager authenticationManager;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        authenticationManager = authConfig.getAuthenticationManager();
+    }
+
+    @Autowired
+    private WebApplicationContext context;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setup() {
+        // Setup MockMvc with Spring Security
+        this.mockMvc = MockMvcBuilders
+            .webAppContextSetup(context)
+            .apply(springSecurity())
+            .build();
+    }
+
+    @Test
+    public void testSuccessfulSsoAuthentication() {
+        // Create authentication request with valid credentials
+        UsernamePasswordAuthenticationToken authRequest =
+            new UsernamePasswordAuthenticationToken("admin", "validPassword");
+
+        // Authenticate
+        Authentication authentication = authenticationManager.authenticate(authRequest);
+
+        // Verify authentication was successful
+        assertTrue(authentication.isAuthenticated());
+        assertEquals("admin", authentication.getName());
+
+        // Verify roles were mapped correctly
+        assertTrue(authentication.getAuthorities().stream()
+            .anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN")));
+    }
+
+    @Test
+    public void testRoleMapping() {
+        // Create authentication request with user that has multiple roles
+        UsernamePasswordAuthenticationToken authRequest =
+            new UsernamePasswordAuthenticationToken("multiRoleUser", "validPassword");
+
+        // Authenticate
+        Authentication authentication = authenticationManager.authenticate(authRequest);
+
+        // Verify authentication was successful
+        assertTrue(authentication.isAuthenticated());
+
+        // Verify all roles were mapped correctly
+        assertTrue(authentication.getAuthorities().stream()
+            .anyMatch(a -> a.getAuthority().equals("ROLE_OWNER_ADMIN")));
+        assertTrue(authentication.getAuthorities().stream()
+            .anyMatch(a -> a.getAuthority().equals("ROLE_VET_ADMIN")));
+    }
+
+    @Test
+    public void testRoleMappingWithoutRolePrefix() {
+        // Create authentication request with user that has roles without ROLE_ prefix
+        UsernamePasswordAuthenticationToken authRequest =
+            new UsernamePasswordAuthenticationToken("unprefixedRoleUser", "validPassword");
+
+        // Authenticate
+        Authentication authentication = authenticationManager.authenticate(authRequest);
+
+        // Verify authentication was successful
+        assertTrue(authentication.isAuthenticated());
+
+        // Verify roles were mapped correctly with ROLE_ prefix added
+        assertTrue(authentication.getAuthorities().stream()
+            .anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN")));
+    }
+
+    @Test
+    public void testFailedSsoAuthentication() {
+        // Create authentication request with invalid credentials
+        UsernamePasswordAuthenticationToken authRequest =
+            new UsernamePasswordAuthenticationToken("admin", "invalidPassword");
+
+        // Attempt to authenticate and expect BadCredentialsException
+        assertThrows(BadCredentialsException.class, () -> {
+            authenticationManager.authenticate(authRequest);
+        });
+    }
+
+    @Test
+    public void testSsoServiceUnavailable() {
+        // Create authentication request with credentials that trigger SSO service unavailable
+        UsernamePasswordAuthenticationToken authRequest =
+            new UsernamePasswordAuthenticationToken("unavailableUser", "anyPassword");
+
+        // Attempt to authenticate and expect AuthenticationServiceException
+        assertThrows(AuthenticationServiceException.class, () -> {
+            authenticationManager.authenticate(authRequest);
+        });
+    }
+
+    @TestConfiguration
+    public static class MockSsoControllerTestConfig {
+
+        @Bean
+        public SecurityFilterChain mockSsoFilterChain(HttpSecurity http) throws Exception {
+            http
+                .securityMatcher("/mock-sso/**")
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests((authz) -> authz
+                    .requestMatchers(HttpMethod.POST, "/mock-sso/auth").permitAll()
+                );
+
+            return http.build();
+        }
+    }
+
+    // Mock SSO Controller for testing
+    @RestController
+    public static class MockSsoController {
+
+        @PostMapping("/mock-sso/auth")
+        public ResponseEntity<Map<String, Object>> authenticate(@RequestHeader("Authorization") String authHeader) {
+            Map<String, Object> response = new HashMap<>();
+
+            if (authHeader != null && authHeader.startsWith("Basic ")) {
+                String base64Credentials = authHeader.substring("Basic ".length());
+                String credentials = new String(Base64.getDecoder().decode(base64Credentials), StandardCharsets.UTF_8);
+                String[] values = credentials.split(":", 2);
+                String username = values[0];
+                String password = values[1];
+
+                if ("unavailableUser".equals(username) || "fallbackUser".equals(username)) {
+                    return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).build();
+                }
+
+                if ("admin".equals(username) && "validPassword".equals(password)) {
+                    response.put("authenticated", true);
+                    response.put("roles", Collections.singletonList("ADMIN"));
+                    return ResponseEntity.ok(response);
+                } else if ("multiRoleUser".equals(username) && "validPassword".equals(password)) {
+                    response.put("authenticated", true);
+                    response.put("roles", List.of("OWNER_ADMIN", "VET_ADMIN"));
+                    return ResponseEntity.ok(response);
+                } else if ("unprefixedRoleUser".equals(username) && "validPassword".equals(password)) {
+                    response.put("authenticated", true);
+                    response.put("roles", Collections.singletonList("ADMIN"));
+                    return ResponseEntity.ok(response);
+                }
+            }
+
+            response.put("authenticated", false);
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(response);
+        }
+    }
+}

--- a/src/test/java/org/springframework/samples/petclinic/security/sso/SsoAuthenticationTest.java
+++ b/src/test/java/org/springframework/samples/petclinic/security/sso/SsoAuthenticationTest.java
@@ -40,6 +40,7 @@ import static org.springframework.security.test.web.servlet.setup.SecurityMockMv
 @Import({SsoAuthenticationTest.MockSsoControllerTestConfig.class, SsoAuthenticationTest.MockSsoController.class})
 @TestPropertySource(properties = {
     "petclinic.security.sso.url=http://localhost:8087/petclinic/mock-sso/auth",
+    "petclinic.security.sso.enabled=true",
     "server.port=8087",
     "petclinic.security.enable=true"
 })


### PR DESCRIPTION
Implement a custom authentication provider that delegates authentication to an external SSO API (such as SAML or a custom REST API).
The implementation should validate SSO responses, map external roles to Spring Security authorities.
The solution should follow Spring Security best practices and integrate seamlessly with the existing security configuration.

SSO service requirements:
- Configure SSO settings in `application.properties`.
- URL should be configured via `petclinic.security.sso.url` property
- support basic authentication
- service response should return: "authenticated" - true or false and "roles" - list of user roles