### PR TITLE
Implement pagination and sorting for the `Pet` entity

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,11 @@
   "jvm_version": "21",
   "build_system": "maven",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "org.springframework.samples.petclinic.rest.controller.PetRestControllerTests#testGetPetsWithPaginationAndCustomParameters",
+      "org.springframework.samples.petclinic.rest.controller.PetRestControllerTests#testGetPetsWithPaginationNotFound",
+      "org.springframework.samples.petclinic.rest.controller.PetRestControllerTests#testGetPetsWithPaginationSuccess"
+    ],
     "pass_to_pass": []
   },
   "environment": {


### PR DESCRIPTION
Implement a new endpoint in the PetRestController to support pagination for the list of pets. The endpoint should allow clients to specify the page number and size of the results. Use Spring Data's Pageable functionality to handle the pagination logic. Ensure to return the paginated list of pets in a ResponseEntity along with appropriate HTTP status codes for different scenarios, such as returning a 404 status when no pets are found.