### PR TITLE
Cache invalidation incorrect on deletion of child entities

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,12 @@
   "jvm_version": "21",
   "build_system": "maven",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "AbstractClinicServiceTests#shouldEvictOwnerCacheWhenDeletingPet",
+      "AbstractClinicServiceTests#shouldEvictOwnerListCacheWhenDeletingPet",
+      "AbstractClinicServiceTests#shouldEvictOwnerSearchCacheWhenDeletingPet",
+      "AbstractClinicServiceTests#shouldEvictPetCacheWhenDeletingVisit"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -6,10 +6,19 @@
   "build_system": "maven",
   "expected": {
     "fail_to_pass": [
-      "AbstractClinicServiceTests#shouldEvictOwnerCacheWhenDeletingPet",
-      "AbstractClinicServiceTests#shouldEvictOwnerListCacheWhenDeletingPet",
-      "AbstractClinicServiceTests#shouldEvictOwnerSearchCacheWhenDeletingPet",
-      "AbstractClinicServiceTests#shouldEvictPetCacheWhenDeletingVisit"
+      "org.springframework.samples.petclinic.service.clinicService.ClinicServiceJdbcTests.shouldEvictOwnerCacheWhenDeletingPet",
+      "org.springframework.samples.petclinic.service.clinicService.ClinicServiceJdbcTests.shouldEvictOwnerListCacheWhenDeletingPet",
+      "org.springframework.samples.petclinic.service.clinicService.ClinicServiceJdbcTests.shouldEvictOwnerSearchCacheWhenDeletingPet",
+      "org.springframework.samples.petclinic.service.clinicService.ClinicServiceJdbcTests.shouldEvictPetCacheWhenDeletingVisit",
+      "org.springframework.samples.petclinic.service.clinicService.ClinicServiceJpaTests.shouldDeleteVisit",
+      "org.springframework.samples.petclinic.service.clinicService.ClinicServiceJpaTests.shouldEvictOwnerCacheWhenDeletingPet",
+      "org.springframework.samples.petclinic.service.clinicService.ClinicServiceJpaTests.shouldEvictOwnerListCacheWhenDeletingPet",
+      "org.springframework.samples.petclinic.service.clinicService.ClinicServiceJpaTests.shouldEvictOwnerSearchCacheWhenDeletingPet",
+      "org.springframework.samples.petclinic.service.clinicService.ClinicServiceJpaTests.shouldEvictPetCacheWhenDeletingVisit",
+      "org.springframework.samples.petclinic.service.clinicService.ClinicServiceSpringDataJpaTests.shouldEvictOwnerCacheWhenDeletingPet",
+      "org.springframework.samples.petclinic.service.clinicService.ClinicServiceSpringDataJpaTests.shouldEvictOwnerListCacheWhenDeletingPet",
+      "org.springframework.samples.petclinic.service.clinicService.ClinicServiceSpringDataJpaTests.shouldEvictOwnerSearchCacheWhenDeletingPet",
+      "org.springframework.samples.petclinic.service.clinicService.ClinicServiceSpringDataJpaTests.shouldEvictPetCacheWhenDeletingVisit"
     ],
     "pass_to_pass": []
   },

--- a/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaVisitRepositoryImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaVisitRepositoryImpl.java
@@ -78,7 +78,9 @@ public class JpaVisitRepositoryImpl implements VisitRepository {
 
 	@Override
 	public void delete(Visit visit) throws DataAccessException {
-        this.em.remove(this.em.contains(visit) ? visit : this.em.merge(visit));
+        this.em.createQuery("DELETE FROM Visit visit WHERE id = :id")
+            .setParameter("id", visit.getId())
+            .executeUpdate();
 	}
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/service/ClinicServiceImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/service/ClinicServiceImpl.java
@@ -75,7 +75,10 @@ public class ClinicServiceImpl implements ClinicService {
 
     @Override
     @Transactional
-    @CacheEvict(value = CacheConfig.CACHE_PETS, allEntries = true)
+    @Caching(evict = {
+        @CacheEvict(value = CacheConfig.CACHE_PETS, allEntries = true),
+        @CacheEvict(value = CacheConfig.CACHE_OWNERS, allEntries = true)
+    })
     public void deletePet(Pet pet) throws DataAccessException {
         petRepository.delete(pet);
     }
@@ -96,7 +99,10 @@ public class ClinicServiceImpl implements ClinicService {
 
     @Override
     @Transactional
-    @CacheEvict(value = CacheConfig.CACHE_VISITS, allEntries = true)
+    @Caching(evict = {
+        @CacheEvict(value = CacheConfig.CACHE_VISITS, allEntries = true),
+        @CacheEvict(value = CacheConfig.CACHE_PETS, allEntries = true)
+    })
     public void deleteVisit(Visit visit) throws DataAccessException {
         visitRepository.delete(visit);
     }

--- a/src/test/java/org/springframework/samples/petclinic/service/CacheEvictionTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/service/CacheEvictionTests.java
@@ -7,6 +7,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.samples.petclinic.config.CacheConfig;
+import org.springframework.samples.petclinic.model.Owner;
+import org.springframework.samples.petclinic.model.Pet;
+import org.springframework.samples.petclinic.model.PetType;
 import org.springframework.samples.petclinic.model.Specialty;
 import org.springframework.samples.petclinic.model.Vet;
 import org.springframework.samples.petclinic.repository.SpecialtyRepository;
@@ -77,6 +80,76 @@ class CacheEvictionTests {
 
         // Repository should only be called once due to caching
         verify(vetRepository, times(1)).findAll();
+    }
+
+    @Test
+    void testOwnerCacheIsPopulatedOnRead() {
+        Owner owner = new Owner();
+        owner.setId(1);
+        owner.setFirstName("George");
+        owner.setLastName("Franklin");
+
+        when(ownerRepository.findById(1)).thenReturn(owner);
+
+        clinicService.findOwnerById(1);
+        clinicService.findOwnerById(1);
+
+        verify(ownerRepository, times(1)).findById(1);
+    }
+
+    @Test
+    void testOwnerListCacheIsPopulatedOnRead() {
+        Owner owner = new Owner();
+        owner.setId(1);
+        owner.setFirstName("George");
+        owner.setLastName("Franklin");
+
+        when(ownerRepository.findAll()).thenReturn(List.of(owner));
+
+        clinicService.findAllOwners();
+        clinicService.findAllOwners();
+
+        verify(ownerRepository, times(1)).findAll();
+    }
+
+    @Test
+    void testOwnerSearchCacheIsPopulatedOnRead() {
+        Owner owner = new Owner();
+        owner.setId(3);
+        owner.setFirstName("Eduardo");
+        owner.setLastName("Rodriquez");
+
+        when(ownerRepository.findByLastName("Rod")).thenReturn(List.of(owner));
+
+        clinicService.findOwnerByLastName("Rod");
+        clinicService.findOwnerByLastName("Rod");
+
+        verify(ownerRepository, times(1)).findByLastName("Rod");
+    }
+
+    @Test
+    void testPetCacheIsPopulatedOnRead() {
+        Owner owner = new Owner();
+        owner.setId(6);
+        owner.setFirstName("Jean");
+        owner.setLastName("Coleman");
+
+        PetType petType = new PetType();
+        petType.setId(1);
+        petType.setName("cat");
+
+        Pet pet = new Pet();
+        pet.setId(7);
+        pet.setName("Samantha");
+        pet.setOwner(owner);
+        pet.setType(petType);
+
+        when(petRepository.findById(7)).thenReturn(pet);
+
+        clinicService.findPetById(7);
+        clinicService.findPetById(7);
+
+        verify(petRepository, times(1)).findById(7);
     }
 
     @Test

--- a/src/test/java/org/springframework/samples/petclinic/service/clinicService/AbstractClinicServiceTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/service/clinicService/AbstractClinicServiceTests.java
@@ -21,6 +21,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.CacheManager;
 import org.springframework.samples.petclinic.model.*;
 import org.springframework.samples.petclinic.service.ClinicService;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.samples.petclinic.util.EntityUtils;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.transaction.annotation.Transactional;
@@ -233,8 +234,60 @@ abstract class AbstractClinicServiceTests {
             pet = this.clinicService.findPetById(1);
 		} catch (Exception e) {
 			pet = null;
-		}
+        }
         assertThat(pet).isNull();
+    }
+
+    @Test
+    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+    void shouldEvictOwnerCacheWhenDeletingPet() {
+        Owner owner = this.clinicService.findOwnerById(3);
+        assertThat(owner.getPets()).extracting(Pet::getId).containsExactlyInAnyOrder(3, 4);
+
+        Pet pet = this.clinicService.findPetById(3);
+        this.clinicService.deletePet(pet);
+
+        owner = this.clinicService.findOwnerById(3);
+        assertThat(owner).isNotNull();
+        assertThat(owner.getPets()).extracting(Pet::getId).containsExactly(4);
+    }
+
+    @Test
+    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+    void shouldEvictOwnerListCacheWhenDeletingPet() {
+        Collection<Owner> owners = this.clinicService.findAllOwners();
+        Owner owner = EntityUtils.getById(owners, Owner.class, 3);
+        assertThat(owner).isNotNull();
+        assertThat(owner.getPets()).extracting(Pet::getId).containsExactlyInAnyOrder(3, 4);
+
+        Pet pet = this.clinicService.findPetById(3);
+        this.clinicService.deletePet(pet);
+
+        owners = this.clinicService.findAllOwners();
+        owner = EntityUtils.getById(owners, Owner.class, 3);
+        assertThat(owner).isNotNull();
+        assertThat(owner.getPets()).extracting(Pet::getId).containsExactly(4);
+    }
+
+    @Test
+    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+    void shouldEvictOwnerSearchCacheWhenDeletingPet() {
+        Collection<Owner> owners = this.clinicService.findOwnerByLastName("Rod");
+        assertThat(owners).hasSize(1);
+
+        Owner owner = owners.iterator().next();
+        assertThat(owner.getId()).isEqualTo(3);
+        assertThat(owner.getPets()).extracting(Pet::getId).containsExactlyInAnyOrder(3, 4);
+
+        Pet pet = this.clinicService.findPetById(3);
+        this.clinicService.deletePet(pet);
+
+        owners = this.clinicService.findOwnerByLastName("Rod");
+        assertThat(owners).hasSize(1);
+
+        owner = owners.iterator().next();
+        assertThat(owner.getId()).isEqualTo(3);
+        assertThat(owner.getPets()).extracting(Pet::getId).containsExactly(4);
     }
 
     @Test
@@ -291,12 +344,28 @@ abstract class AbstractClinicServiceTests {
     void shouldDeleteVisit(){
     	Visit visit = this.clinicService.findVisitById(1);
         this.clinicService.deleteVisit(visit);
+        clearCache();
         try {
         	visit = this.clinicService.findVisitById(1);
 		} catch (Exception e) {
 			visit = null;
 		}
         assertThat(visit).isNull();
+    }
+
+    @Test
+    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+    void shouldEvictPetCacheWhenDeletingVisit() {
+        Pet pet = this.clinicService.findPetById(7);
+        assertThat(pet.getVisits()).hasSize(2);
+
+        Visit visit = this.clinicService.findVisitById(1);
+        this.clinicService.deleteVisit(visit);
+
+        pet = this.clinicService.findPetById(7);
+        assertThat(pet).isNotNull();
+        assertThat(pet.getVisits()).hasSize(1);
+        assertThat(pet.getVisits()).noneMatch(existingVisit -> existingVisit.getId().equals(1));
     }
 
     @Test


### PR DESCRIPTION
## Description

Deleting a child entity does not invalidate the cache of its parent.
As a result, fetching the parent after the deletion returns stale data with the deleted child still present.

## Steps to Reproduce

### Scenario 1: Deleting a pet leaves the owner cache stale

1. `GET /api/owners/1` — fetch owner; response is cached.

   **Response:**
   ```json
   {
     "id": 1,
     "firstName": "John",
     "lastName": "Doe",
     "pets": [{ "id": 1, "name": "Whiskers" }]
   }
   ```

2. `DELETE /api/pets/1` — returns `204 No Content`.

3. `GET /api/owners/1` — fetch the owner again.

   **Expected:** owner with an empty `pets` list.

   **Actual:** same stale response as step 1, deleted pet still present:
   ```json
   {
     "id": 1,
     "firstName": "John",
     "lastName": "Doe",
     "pets": [{ "id": 1, "name": "Whiskers" }]
   }
   ```

### Scenario 2: Deleting a visit leaves the pet cache stale

1. `GET /api/pets/1` — fetch pet; response is cached.

   **Response:**
   ```json
   {
     "id": 1,
     "name": "Rex",
     "visits": [{ "id": 1, "description": "Annual checkup", "date": "2024-06-15" }]
   }
   ```

2. `DELETE /api/visits/1` — returns `204 No Content`.

3. `GET /api/pets/1` — fetch the pet again.

   **Expected:** pet with an empty `visits` list.

   **Actual:** same stale response as step 1, deleted visit still present:
   ```json
   {
     "id": 1,
     "name": "Rex",
     "visits": [{ "id": 1, "description": "Annual checkup", "date": "2024-06-15" }]
   }
   ```

Note: in the manual JPA ("jpa") profile, DELETE /api/visits/{id} does not actually delete the visit from the database. This must also be resolved; otherwise the visit scenario remains broken even with correct cache eviction.