### PR TITLE
`GET /api/pets` is slow — owner is fetched separately for each pet

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -6,12 +6,12 @@
   "build_system": "maven",
   "expected": {
     "fail_to_pass": [
-      "org.springframework.samples.petclinic.service.clinicService.N1SelectOptimizationTest",
       "org.springframework.samples.petclinic.rest.controller.OwnerRestControllerSpringDataJpaN1IntegrationTests",
       "org.springframework.samples.petclinic.rest.controller.OwnerRestControllerJpaN1IntegrationTests",
-      "org.springframework.samples.petclinic.rest.controller.VetRestControllerJpaN1IntegrationTests",
       "org.springframework.samples.petclinic.rest.controller.PetRestControllerN1IntegrationTests",
-      "org.springframework.samples.petclinic.rest.controller.PetRestControllerJpaN1IntegrationTests"
+      "org.springframework.samples.petclinic.rest.controller.PetRestControllerJpaN1IntegrationTests",
+      "org.springframework.samples.petclinic.service.clinicService.N1SelectOptimizationTest.findAllOwners_shouldNotTriggerNPlusOneForPets",
+      "org.springframework.samples.petclinic.rest.controller.VetRestControllerJpaN1IntegrationTests.listVets_shouldFetchAllAssociationsInSingleQuery"
     ],
     "pass_to_pass": []
   },

--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,14 @@
   "jvm_version": "21",
   "build_system": "maven",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "org.springframework.samples.petclinic.service.clinicService.N1SelectOptimizationTest",
+      "org.springframework.samples.petclinic.rest.controller.OwnerRestControllerSpringDataJpaN1IntegrationTests",
+      "org.springframework.samples.petclinic.rest.controller.OwnerRestControllerJpaN1IntegrationTests",
+      "org.springframework.samples.petclinic.rest.controller.VetRestControllerJpaN1IntegrationTests",
+      "org.springframework.samples.petclinic.rest.controller.PetRestControllerN1IntegrationTests",
+      "org.springframework.samples.petclinic.rest.controller.PetRestControllerJpaN1IntegrationTests"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/src/main/java/org/springframework/samples/petclinic/model/Owner.java
+++ b/src/main/java/org/springframework/samples/petclinic/model/Owner.java
@@ -19,8 +19,6 @@ import org.springframework.beans.support.MutableSortDefinition;
 import org.springframework.beans.support.PropertyComparator;
 import org.springframework.core.style.ToStringCreator;
 
-import org.hibernate.annotations.BatchSize;
-
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Digits;
 import jakarta.validation.constraints.NotEmpty;
@@ -53,8 +51,7 @@ public class Owner extends Person {
     @Pattern(regexp = "^[0-9]{10}$", message = "Phone number must be exactly 10 digits")
     private String telephone;
 
-    @OneToMany(cascade = CascadeType.ALL, mappedBy = "owner", fetch = FetchType.EAGER)
-    @BatchSize(size = 10)
+    @OneToMany(cascade = CascadeType.ALL, mappedBy = "owner", fetch = FetchType.LAZY)
     private Set<Pet> pets;
 
     public String getAddress() {

--- a/src/main/java/org/springframework/samples/petclinic/model/Pet.java
+++ b/src/main/java/org/springframework/samples/petclinic/model/Pet.java
@@ -19,8 +19,6 @@ import org.springframework.beans.support.MutableSortDefinition;
 import org.springframework.beans.support.PropertyComparator;
 import org.springframework.format.annotation.DateTimeFormat;
 
-import org.hibernate.annotations.BatchSize;
-
 import jakarta.persistence.*;
 import java.time.LocalDate;
 import java.util.*;
@@ -48,8 +46,7 @@ public class Pet extends NamedEntity {
     @JoinColumn(name = "owner_id")
     private Owner owner;
 
-    @OneToMany(cascade = CascadeType.ALL, mappedBy = "pet", fetch = FetchType.EAGER)
-    @BatchSize(size = 25)
+    @OneToMany(cascade = CascadeType.ALL, mappedBy = "pet", fetch = FetchType.LAZY)
     private Set<Visit> visits;
 
     public LocalDate getBirthDate() {

--- a/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaOwnerRepositoryImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaOwnerRepositoryImpl.java
@@ -23,7 +23,6 @@ import jakarta.persistence.Query;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.dao.DataAccessException;
-import org.springframework.orm.hibernate5.support.OpenSessionInViewFilter;
 import org.springframework.samples.petclinic.model.Owner;
 import org.springframework.samples.petclinic.repository.OwnerRepository;
 import org.springframework.stereotype.Repository;
@@ -46,26 +45,29 @@ public class JpaOwnerRepositoryImpl implements OwnerRepository {
 
 
     /**
-     * Important: in the current version of this method, we load Owners with all their Pets and Visits while
-     * we do not need Visits at all and we only need one property from the Pet objects (the 'name' property).
-     * There are some ways to improve it such as:
-     * - creating a Ligtweight class (example here: https://community.jboss.org/wiki/LightweightClass)
-     * - Turning on lazy-loading and using {@link OpenSessionInViewFilter}
+     * Important: owner REST responses serialize pets, pet types and pet visits. Fetching them here keeps the
+     * web layer independent from an open persistence session.
      */
     @SuppressWarnings("unchecked")
     public Collection<Owner> findByLastName(String lastName) {
-        // using 'join fetch' because a single query should load both owners and pets
-        // using 'left join fetch' because it might happen that an owner does not have pets yet
-        Query query = this.em.createQuery("SELECT DISTINCT owner FROM Owner owner left join fetch owner.pets WHERE owner.lastName LIKE :lastName");
+        Query query = this.em.createQuery(
+            "SELECT DISTINCT owner FROM Owner owner "
+                + "left join fetch owner.pets pet "
+                + "left join fetch pet.type "
+                + "left join fetch pet.visits "
+                + "WHERE owner.lastName LIKE :lastName");
         query.setParameter("lastName", lastName + "%");
         return query.getResultList();
     }
 
     @Override
     public Owner findById(int id) {
-        // using 'join fetch' because a single query should load both owners and pets
-        // using 'left join fetch' because it might happen that an owner does not have pets yet
-        Query query = this.em.createQuery("SELECT owner FROM Owner owner left join fetch owner.pets WHERE owner.id =:id");
+        Query query = this.em.createQuery(
+            "SELECT DISTINCT owner FROM Owner owner "
+                + "left join fetch owner.pets pet "
+                + "left join fetch pet.type "
+                + "left join fetch pet.visits "
+                + "WHERE owner.id = :id");
         query.setParameter("id", id);
         return (Owner) query.getSingleResult();
     }
@@ -84,7 +86,11 @@ public class JpaOwnerRepositoryImpl implements OwnerRepository {
 	@SuppressWarnings("unchecked")
 	@Override
 	public Collection<Owner> findAll() throws DataAccessException {
-		Query query = this.em.createQuery("SELECT owner FROM Owner owner");
+		Query query = this.em.createQuery(
+            "SELECT DISTINCT owner FROM Owner owner "
+                + "left join fetch owner.pets pet "
+                + "left join fetch pet.type "
+                + "left join fetch pet.visits");
         return query.getResultList();
 	}
 

--- a/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaPetRepositoryImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaPetRepositoryImpl.java
@@ -52,7 +52,16 @@ public class JpaPetRepositoryImpl implements PetRepository {
 
     @Override
     public Pet findById(int id) {
-        return this.em.find(Pet.class, id);
+        return this.em.createQuery(
+                "SELECT pet FROM Pet pet " +
+                    "left join fetch pet.visits " +
+                    "left join fetch pet.type " +
+                    "left join fetch pet.owner " +
+                    "WHERE pet.id = :id", Pet.class)
+            .setParameter("id", id)
+            .getResultStream()
+            .findFirst()
+            .orElse(null);
     }
 
     @Override
@@ -67,7 +76,12 @@ public class JpaPetRepositoryImpl implements PetRepository {
 	@SuppressWarnings("unchecked")
 	@Override
 	public Collection<Pet> findAll() throws DataAccessException {
-		return this.em.createQuery("SELECT pet FROM Pet pet").getResultList();
+		return this.em.createQuery(
+			"SELECT DISTINCT pet FROM Pet pet " +
+				"left join fetch pet.visits " +
+				"left join fetch pet.type " +
+				"left join fetch pet.owner")
+			.getResultList();
 	}
 
 	@Override

--- a/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaVetRepositoryImpl.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/jpa/JpaVetRepositoryImpl.java
@@ -50,7 +50,8 @@ public class JpaVetRepositoryImpl implements VetRepository {
 	@SuppressWarnings("unchecked")
 	@Override
 	public Collection<Vet> findAll() throws DataAccessException {
-		return this.em.createQuery("SELECT vet FROM Vet vet").getResultList();
+		return this.em.createQuery(
+			"SELECT DISTINCT vet FROM Vet vet left join fetch vet.specialties").getResultList();
 	}
 
 	@Override

--- a/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataOwnerRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataOwnerRepository.java
@@ -36,14 +36,34 @@ import org.springframework.dao.DataAccessException;
 public interface SpringDataOwnerRepository extends OwnerRepository, Repository<Owner, Integer> {
 
     @Override
-    @Query("SELECT DISTINCT owner FROM Owner owner left join fetch owner.pets WHERE owner.lastName LIKE :lastName%")
+    @Query("""
+        SELECT DISTINCT owner
+        FROM Owner owner
+        left join fetch owner.pets pet
+        left join fetch pet.type
+        left join fetch pet.visits
+        WHERE owner.lastName LIKE :lastName%
+        """)
     Collection<Owner> findByLastName(@Param("lastName") String lastName);
 
     @Override
-    @Query("SELECT owner FROM Owner owner left join fetch owner.pets WHERE owner.id =:id")
+    @Query("""
+        SELECT DISTINCT owner
+        FROM Owner owner
+        left join fetch owner.pets pet
+        left join fetch pet.type
+        left join fetch pet.visits
+        WHERE owner.id = :id
+        """)
     Owner findById(@Param("id") int id);
 
     @Override
-    @Query("SELECT DISTINCT owner FROM Owner owner left join fetch owner.pets p left join fetch p.type")
+    @Query("""
+        SELECT DISTINCT owner
+        FROM Owner owner
+        left join fetch owner.pets pet
+        left join fetch pet.type
+        left join fetch pet.visits
+        """)
     Collection<Owner> findAll() throws DataAccessException;
 }

--- a/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataPetRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/repository/springdatajpa/SpringDataPetRepository.java
@@ -15,12 +15,14 @@
  */
 package org.springframework.samples.petclinic.repository.springdatajpa;
 
+import java.util.Collection;
 import java.util.List;
 
 import org.springframework.context.annotation.Profile;
 import org.springframework.dao.DataAccessException;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.samples.petclinic.model.Pet;
 import org.springframework.samples.petclinic.model.PetType;
 import org.springframework.samples.petclinic.repository.PetRepository;
@@ -34,6 +36,21 @@ import org.springframework.samples.petclinic.repository.PetRepository;
 
 @Profile("spring-data-jpa")
 public interface SpringDataPetRepository extends PetRepository, Repository<Pet, Integer>, PetRepositoryOverride {
+
+    @Override
+    @Query("SELECT DISTINCT pet FROM Pet pet " +
+        "left join fetch pet.visits " +
+        "left join fetch pet.type " +
+        "left join fetch pet.owner")
+    Collection<Pet> findAll() throws DataAccessException;
+
+    @Override
+    @Query("SELECT pet FROM Pet pet " +
+        "left join fetch pet.visits " +
+        "left join fetch pet.type " +
+        "left join fetch pet.owner " +
+        "WHERE pet.id = :id")
+    Pet findById(@Param("id") int id) throws DataAccessException;
 
     @Override
     @Query("SELECT ptype FROM PetType ptype ORDER BY ptype.name")

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/AbstractOwnerRestControllerIntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/AbstractOwnerRestControllerIntegrationTests.java
@@ -1,0 +1,131 @@
+package org.springframework.samples.petclinic.rest.controller;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.samples.petclinic.rest.dto.OwnerDto;
+import org.springframework.samples.petclinic.rest.dto.PetDto;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Pass-to-pass regression guardrails for owner REST endpoints.
+ */
+abstract class AbstractOwnerRestControllerIntegrationTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @WithMockUser(roles = "OWNER_ADMIN")
+    void listOwners_shouldReturnPetsWithVisits() throws Exception {
+        // Regression test: listing owners must still serialize pets and visits.
+        MvcResult result = mockMvc.perform(get("/petclinic/api/owners")
+                .contextPath("/petclinic")
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andReturn();
+
+        List<OwnerDto> owners = objectMapper.readValue(
+            result.getResponse().getContentAsByteArray(),
+            new TypeReference<List<OwnerDto>>() { }
+        );
+
+        assertThat(owners).hasSize(10);
+
+        OwnerDto george = ownerById(owners, 1);
+        assertThat(george.getFirstName()).isEqualTo("George");
+        assertThat(george.getLastName()).isEqualTo("Franklin");
+        PetDto leo = petById(george.getPets(), 1);
+        assertThat(leo.getType().getName()).isEqualTo("cat");
+        assertThat(leo.getVisits()).isEmpty();
+
+        OwnerDto jean = ownerById(owners, 6);
+        assertThat(jean.getFirstName()).isEqualTo("Jean");
+        assertThat(jean.getLastName()).isEqualTo("Coleman");
+        assertThat(jean.getPets()).hasSize(2);
+        assertPetHasVisits(jean.getPets(), 7, "Samantha", 2);
+        assertPetHasVisits(jean.getPets(), 8, "Max", 2);
+    }
+
+    @Test
+    @WithMockUser(roles = "OWNER_ADMIN")
+    void getOwner_shouldReturnPetsWithVisits() throws Exception {
+        // Regression test: fetching a single owner must still serialize pets and visits.
+        MvcResult result = mockMvc.perform(get("/petclinic/api/owners/6")
+                .contextPath("/petclinic")
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andReturn();
+
+        OwnerDto owner = objectMapper.readValue(result.getResponse().getContentAsByteArray(), OwnerDto.class);
+
+        assertThat(owner.getId()).isEqualTo(6);
+        assertThat(owner.getFirstName()).isEqualTo("Jean");
+        assertThat(owner.getLastName()).isEqualTo("Coleman");
+        assertThat(owner.getPets()).hasSize(2);
+        assertPetHasVisits(owner.getPets(), 7, "Samantha", 2);
+        assertPetHasVisits(owner.getPets(), 8, "Max", 2);
+    }
+
+    @Test
+    @WithMockUser(roles = "OWNER_ADMIN")
+    void listOwnersByLastName_shouldReturnMatchedOwnerWithPetVisits() throws Exception {
+        // Regression test: owner search must still serialize pets and visits.
+        MvcResult result = mockMvc.perform(get("/petclinic/api/owners")
+                .contextPath("/petclinic")
+                .queryParam("lastName", "Coleman")
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andReturn();
+
+        List<OwnerDto> owners = objectMapper.readValue(
+            result.getResponse().getContentAsByteArray(),
+            new TypeReference<List<OwnerDto>>() { }
+        );
+
+        assertThat(owners).hasSize(1);
+        OwnerDto owner = ownerById(owners, 6);
+        assertThat(owner.getFirstName()).isEqualTo("Jean");
+        assertThat(owner.getLastName()).isEqualTo("Coleman");
+        assertThat(owner.getPets()).hasSize(2);
+        assertPetHasVisits(owner.getPets(), 7, "Samantha", 2);
+        assertPetHasVisits(owner.getPets(), 8, "Max", 2);
+    }
+
+    private OwnerDto ownerById(List<OwnerDto> owners, int id) {
+        return owners.stream()
+            .filter(owner -> owner.getId() != null && owner.getId() == id)
+            .findFirst()
+            .orElseThrow();
+    }
+
+    private PetDto petById(List<PetDto> pets, int id) {
+        return pets.stream()
+            .filter(pet -> pet.getId() != null && pet.getId() == id)
+            .findFirst()
+            .orElseThrow();
+    }
+
+    private void assertPetHasVisits(List<PetDto> pets, int petId, String expectedName, int expectedVisitCount) {
+        PetDto pet = petById(pets, petId);
+        assertThat(pet.getName()).isEqualTo(expectedName);
+        assertThat(pet.getVisits()).hasSize(expectedVisitCount);
+    }
+}

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/AbstractOwnerRestControllerN1IntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/AbstractOwnerRestControllerN1IntegrationTests.java
@@ -1,0 +1,137 @@
+package org.springframework.samples.petclinic.rest.controller;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.EntityManagerFactory;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.samples.petclinic.rest.dto.OwnerDto;
+import org.springframework.samples.petclinic.rest.dto.PetDto;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+abstract class AbstractOwnerRestControllerN1IntegrationTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private EntityManagerFactory entityManagerFactory;
+
+    private Statistics statistics;
+
+    @BeforeEach
+    void setUp() {
+        statistics = entityManagerFactory.unwrap(SessionFactory.class).getStatistics();
+        statistics.setStatisticsEnabled(true);
+        statistics.clear();
+    }
+
+    @Test
+    @WithMockUser(roles = "OWNER_ADMIN")
+    void listOwners_shouldFetchAllAssociationsInSingleQuery() throws Exception {
+        MvcResult result = mockMvc.perform(get("/petclinic/api/owners")
+                .contextPath("/petclinic")
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andReturn();
+
+        List<OwnerDto> owners = objectMapper.readValue(
+            result.getResponse().getContentAsByteArray(),
+            new TypeReference<List<OwnerDto>>() { }
+        );
+
+        assertThat(owners).hasSize(10);
+
+        OwnerDto jean = ownerById(owners, 6);
+        assertThat(jean.getPets()).hasSize(2);
+        PetDto samantha = petById(jean.getPets(), 7);
+        assertThat(samantha.getVisits()).hasSize(2);
+
+        assertThat(statistics.getPrepareStatementCount())
+            .as("all entities are fetched in a single join fetch query")
+            .isEqualTo(1);
+    }
+
+    @Test
+    @WithMockUser(roles = "OWNER_ADMIN")
+    void listOwnersByLastName_shouldFetchAllAssociationsInSingleQuery() throws Exception {
+        statistics.clear();
+
+        MvcResult result = mockMvc.perform(get("/petclinic/api/owners")
+                .contextPath("/petclinic")
+                .queryParam("lastName", "Coleman")
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andReturn();
+
+        List<OwnerDto> owners = objectMapper.readValue(
+            result.getResponse().getContentAsByteArray(),
+            new TypeReference<List<OwnerDto>>() { }
+        );
+
+        assertThat(owners).hasSize(1);
+        OwnerDto jean = ownerById(owners, 6);
+        assertThat(jean.getPets()).hasSize(2);
+        PetDto samantha = petById(jean.getPets(), 7);
+        assertThat(samantha.getVisits()).hasSize(2);
+
+        assertThat(statistics.getPrepareStatementCount())
+            .as("all entities are fetched in a single join fetch query")
+            .isEqualTo(1);
+    }
+
+    @Test
+    @WithMockUser(roles = "OWNER_ADMIN")
+    void getOwner_shouldFetchAllAssociationsInSingleQuery() throws Exception {
+        MvcResult result = mockMvc.perform(get("/petclinic/api/owners/6")
+                .contextPath("/petclinic")
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andReturn();
+
+        OwnerDto owner = objectMapper.readValue(
+            result.getResponse().getContentAsByteArray(), OwnerDto.class);
+
+        assertThat(owner.getId()).isEqualTo(6);
+        assertThat(owner.getPets()).hasSize(2);
+        PetDto samantha = petById(owner.getPets(), 7);
+        assertThat(samantha.getVisits()).hasSize(2);
+
+        assertThat(statistics.getPrepareStatementCount())
+            .as("all entities are fetched in a single join fetch query")
+            .isEqualTo(1);
+    }
+
+    private OwnerDto ownerById(List<OwnerDto> owners, int id) {
+        return owners.stream()
+            .filter(owner -> owner.getId() != null && owner.getId() == id)
+            .findFirst()
+            .orElseThrow();
+    }
+
+    private PetDto petById(List<PetDto> pets, int id) {
+        return pets.stream()
+            .filter(pet -> pet.getId() != null && pet.getId() == id)
+            .findFirst()
+            .orElseThrow();
+    }
+}

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/AbstractPetRestControllerN1IntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/AbstractPetRestControllerN1IntegrationTests.java
@@ -1,0 +1,118 @@
+package org.springframework.samples.petclinic.rest.controller;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.EntityManagerFactory;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.samples.petclinic.rest.dto.PetDto;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+abstract class AbstractPetRestControllerN1IntegrationTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private EntityManagerFactory entityManagerFactory;
+
+    private Statistics statistics;
+
+    @BeforeEach
+    void setUp() {
+        statistics = entityManagerFactory.unwrap(SessionFactory.class).getStatistics();
+        statistics.setStatisticsEnabled(true);
+        statistics.clear();
+    }
+
+    @Test
+    @WithMockUser(roles = "OWNER_ADMIN")
+    void listPets_shouldReturnDistinctPetDtosWithoutOwnerNPlusOne() throws Exception {
+        MvcResult result = mockMvc.perform(get("/petclinic/api/pets")
+                .contextPath("/petclinic")
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andReturn();
+
+        List<PetDto> pets = objectMapper.readValue(
+            result.getResponse().getContentAsByteArray(),
+            new TypeReference<List<PetDto>>() { }
+        );
+
+        assertThat(pets).hasSize(13);
+        assertThat(pets).extracting(PetDto::getId).doesNotHaveDuplicates();
+        assertThat(pets).allSatisfy(pet -> {
+            assertThat(pet.getOwnerId()).as("ownerId for pet %s", pet.getId()).isNotNull();
+            assertThat(pet.getType()).as("type for pet %s", pet.getId()).isNotNull();
+            assertThat(pet.getType().getName()).as("type name for pet %s", pet.getId()).isNotBlank();
+            assertThat(pet.getVisits()).as("visits for pet %s", pet.getId()).isNotNull();
+        });
+
+        PetDto leo = petById(pets, 1);
+        assertThat(leo.getOwnerId()).isEqualTo(1);
+        assertThat(leo.getType().getName()).isEqualTo("cat");
+        assertThat(leo.getVisits()).isEmpty();
+
+        PetDto samantha = petById(pets, 7);
+        assertThat(samantha.getOwnerId()).isEqualTo(6);
+        assertThat(samantha.getType().getName()).isEqualTo("cat");
+        assertThat(samantha.getVisits()).hasSize(2);
+
+        PetDto max = petById(pets, 8);
+        assertThat(max.getOwnerId()).isEqualTo(6);
+        assertThat(max.getType().getName()).isEqualTo("cat");
+        assertThat(max.getVisits()).hasSize(2);
+
+        assertThat(statistics.getPrepareStatementCount())
+            .as("all entities are fetched in a single join fetch query")
+            .isEqualTo(1);
+    }
+
+    @Test
+    @WithMockUser(roles = "OWNER_ADMIN")
+    void getPet_shouldFetchAllAssociationsInSingleQuery() throws Exception {
+        MvcResult result = mockMvc.perform(get("/petclinic/api/pets/7")
+                .contextPath("/petclinic")
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andReturn();
+
+        PetDto pet = objectMapper.readValue(
+            result.getResponse().getContentAsByteArray(), PetDto.class);
+
+        assertThat(pet.getId()).isEqualTo(7);
+        assertThat(pet.getName()).isEqualTo("Samantha");
+        assertThat(pet.getOwnerId()).isEqualTo(6);
+        assertThat(pet.getType().getName()).isEqualTo("cat");
+        assertThat(pet.getVisits()).hasSize(2);
+
+        assertThat(statistics.getPrepareStatementCount())
+            .as("all entities are fetched in a single join fetch query")
+            .isEqualTo(1);
+    }
+
+    private PetDto petById(List<PetDto> pets, int id) {
+        return pets.stream()
+            .filter(pet -> pet.getId() != null && pet.getId() == id)
+            .findFirst()
+            .orElseThrow();
+    }
+}

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/AbstractVetRestControllerN1IntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/AbstractVetRestControllerN1IntegrationTests.java
@@ -1,0 +1,92 @@
+package org.springframework.samples.petclinic.rest.controller;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.EntityManagerFactory;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.samples.petclinic.rest.dto.VetDto;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+abstract class AbstractVetRestControllerN1IntegrationTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private EntityManagerFactory entityManagerFactory;
+
+    private Statistics statistics;
+
+    @BeforeEach
+    void setUp() {
+        statistics = entityManagerFactory.unwrap(SessionFactory.class).getStatistics();
+        statistics.setStatisticsEnabled(true);
+        statistics.clear();
+    }
+
+    @Test
+    @WithMockUser(roles = "VET_ADMIN")
+    void listVets_shouldFetchAllAssociationsInSingleQuery() throws Exception {
+        MvcResult result = mockMvc.perform(get("/petclinic/api/vets")
+                .contextPath("/petclinic")
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andReturn();
+
+        List<VetDto> vets = objectMapper.readValue(
+            result.getResponse().getContentAsByteArray(),
+            new TypeReference<List<VetDto>>() { }
+        );
+
+        assertThat(vets).hasSize(6);
+
+        VetDto linda = vets.stream()
+            .filter(v -> v.getId() != null && v.getId() == 3)
+            .findFirst()
+            .orElseThrow();
+        assertThat(linda.getSpecialties()).hasSize(2);
+
+        assertThat(statistics.getPrepareStatementCount())
+            .as("all entities are fetched in a single join fetch query")
+            .isEqualTo(1);
+    }
+
+    @Test
+    @WithMockUser(roles = "VET_ADMIN")
+    void getVet_shouldFetchAllAssociationsInSingleQuery() throws Exception {
+        MvcResult result = mockMvc.perform(get("/petclinic/api/vets/3")
+                .contextPath("/petclinic")
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andReturn();
+
+        VetDto vet = objectMapper.readValue(
+            result.getResponse().getContentAsByteArray(), VetDto.class);
+
+        assertThat(vet.getId()).isEqualTo(3);
+        assertThat(vet.getSpecialties()).hasSize(2);
+
+        assertThat(statistics.getPrepareStatementCount())
+            .as("all entities are fetched in a single join fetch query")
+            .isEqualTo(1);
+    }
+}

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/OwnerRestControllerJpaIntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/OwnerRestControllerJpaIntegrationTests.java
@@ -1,0 +1,11 @@
+package org.springframework.samples.petclinic.rest.controller;
+
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles({"jpa", "hsqldb"})
+class OwnerRestControllerJpaIntegrationTests extends AbstractOwnerRestControllerIntegrationTests {
+}

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/OwnerRestControllerJpaN1IntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/OwnerRestControllerJpaN1IntegrationTests.java
@@ -1,0 +1,11 @@
+package org.springframework.samples.petclinic.rest.controller;
+
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles({"jpa", "hsqldb"})
+class OwnerRestControllerJpaN1IntegrationTests extends AbstractOwnerRestControllerN1IntegrationTests {
+}

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/OwnerRestControllerSpringDataJpaIntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/OwnerRestControllerSpringDataJpaIntegrationTests.java
@@ -1,0 +1,11 @@
+package org.springframework.samples.petclinic.rest.controller;
+
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles({"spring-data-jpa", "hsqldb"})
+class OwnerRestControllerSpringDataJpaIntegrationTests extends AbstractOwnerRestControllerIntegrationTests {
+}

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/OwnerRestControllerSpringDataJpaN1IntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/OwnerRestControllerSpringDataJpaN1IntegrationTests.java
@@ -1,0 +1,11 @@
+package org.springframework.samples.petclinic.rest.controller;
+
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles({"spring-data-jpa", "hsqldb"})
+class OwnerRestControllerSpringDataJpaN1IntegrationTests extends AbstractOwnerRestControllerN1IntegrationTests {
+}

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/PetRestControllerJpaN1IntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/PetRestControllerJpaN1IntegrationTests.java
@@ -1,0 +1,11 @@
+package org.springframework.samples.petclinic.rest.controller;
+
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles({"jpa", "hsqldb"})
+class PetRestControllerJpaN1IntegrationTests extends AbstractPetRestControllerN1IntegrationTests {
+}

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/PetRestControllerN1IntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/PetRestControllerN1IntegrationTests.java
@@ -1,0 +1,11 @@
+package org.springframework.samples.petclinic.rest.controller;
+
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles({"spring-data-jpa", "hsqldb"})
+class PetRestControllerN1IntegrationTests extends AbstractPetRestControllerN1IntegrationTests {
+}

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/VetRestControllerJpaN1IntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/VetRestControllerJpaN1IntegrationTests.java
@@ -1,0 +1,11 @@
+package org.springframework.samples.petclinic.rest.controller;
+
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles({"jpa", "hsqldb"})
+class VetRestControllerJpaN1IntegrationTests extends AbstractVetRestControllerN1IntegrationTests {
+}

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/VetRestControllerSpringDataJpaN1IntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/VetRestControllerSpringDataJpaN1IntegrationTests.java
@@ -1,0 +1,11 @@
+package org.springframework.samples.petclinic.rest.controller;
+
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles({"spring-data-jpa", "hsqldb"})
+class VetRestControllerSpringDataJpaN1IntegrationTests extends AbstractVetRestControllerN1IntegrationTests {
+}

--- a/src/test/java/org/springframework/samples/petclinic/service/clinicService/N1SelectOptimizationTest.java
+++ b/src/test/java/org/springframework/samples/petclinic/service/clinicService/N1SelectOptimizationTest.java
@@ -25,12 +25,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * <p>Optimizations applied:
  * <ul>
- *   <li>{@code @BatchSize(size = 10)} on {@code Owner.pets}, {@code Pet.visits}, and
- *       {@code Vet.specialties} - Hibernate batches secondary selects into groups of 10,
- *       reducing N queries to ceil(N/10) queries.</li>
- *   <li>Explicit JPQL {@code left join fetch} in {@code findAll()} queries for Owner and Vet
- *       repositories - loads associations in a single SQL JOIN, eliminating secondary selects
- *       entirely for these operations.</li>
+ *   <li>Owner and vet repository list queries use explicit JPQL {@code left join fetch}
+ *       so the associations needed by those list operations are loaded in the primary query.</li>
+ *   <li>Pet list queries now fetch only the associations required by the REST payload
+ *       ({@code owner}, {@code type}, {@code visits}) instead of traversing {@code owner.pets}.</li>
  * </ul>
  */
 @SpringBootTest
@@ -76,9 +74,9 @@ class N1SelectOptimizationTest {
         // With join fetch, query count should be 1 (single JOIN query)
         // We allow a small buffer for framework overhead queries
         assertThat(queryCount)
-            .as("Expected at most 2 queries for findAllOwners (join fetch eliminates N+1), "
+            .as("all entities are fetched in a single join fetch query, "
                 + "but got %d queries for %d owners", queryCount, ownerCount)
-            .isLessThanOrEqualTo(2);
+            .isEqualTo(1);
     }
 
     /**
@@ -104,9 +102,9 @@ class N1SelectOptimizationTest {
         // With N+1, query count would be: 1 (vets) + N (specialties per vet) = vetCount + 1
         // With join fetch, query count should be 1 (single JOIN query)
         assertThat(queryCount)
-            .as("Expected at most 2 queries for findAllVets (join fetch eliminates N+1), "
+            .as("all entities are fetched in a single join fetch query, "
                 + "but got %d queries for %d vets", queryCount, vetCount)
-            .isLessThanOrEqualTo(2);
+            .isEqualTo(1);
     }
 
     /**


### PR DESCRIPTION
## Description

Calling `GET /api/pets` fires an individual query to find the associated owner for each pet. 

With 13 pets belonging to 10 distinct owners, the endpoint executes 11 queries instead of 2:

```sql
select p1_0.id,p1_0.birth_date,p1_0.name,p1_0.owner_id,p1_0.type_id from pets p1_0

select o1_0.id,...,o1_0.telephone from owners o1_0
  left join pets p1_0 on o1_0.id=p1_0.owner_id
  left join types t1_0 on t1_0.id=p1_0.type_id
  left join visits v1_0 on p1_0.id=v1_0.pet_id
  where o1_0.id=?
... repeated 10 more times, once per unique owner
```

Same also happens for other endpoints:
- `GET /api/pets/{id}` — fetches owner, type and visits separately
- `GET /api/owners` — fetches visits separately for each owner's pets
- `GET /api/owners/{id}` — same as above
- `GET /api/owners?lastName=...` — same as above
- `GET /api/vets` — fetches specialties separately for each vet
