### PR TITLE
Role-protected API endpoints return 500 regardless of authentication

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,17 @@
   "jvm_version": "21",
   "build_system": "maven",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "org.springframework.samples.petclinic.rest.controller.AuthControllerTests",
+      "org.springframework.samples.petclinic.rest.controller.OwnerRestControllerTests",
+      "org.springframework.samples.petclinic.rest.controller.PetRestControllerTests",
+      "org.springframework.samples.petclinic.rest.controller.PetTypeRestControllerTests",
+      "org.springframework.samples.petclinic.rest.controller.RoleAuthIntegrationTest",
+      "org.springframework.samples.petclinic.rest.controller.RoleAuthIntegrationTest",
+      "org.springframework.samples.petclinic.rest.controller.SpecialtyRestControllerTests",
+      "org.springframework.samples.petclinic.rest.controller.UserRestControllerTests",
+      "org.springframework.samples.petclinic.rest.controller.VetRestControllerTests"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/pom.xml
+++ b/pom.xml
@@ -186,6 +186,28 @@
             <artifactId>jaxb-api</artifactId>
             <version>${jaxb-api.version}</version>
         </dependency>
+
+        <!-- WireMock for OAuth2 server mocking -->
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-jre8-standalone</artifactId>
+            <version>2.35.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Apache HttpClient for OAuth2 testing with cookie store -->
+        <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Awaitility for async testing -->
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <reporting>

--- a/src/main/java/org/springframework/samples/petclinic/rest/advice/ExceptionControllerAdvice.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/advice/ExceptionControllerAdvice.java
@@ -18,6 +18,7 @@ package org.springframework.samples.petclinic.rest.advice;
 
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
@@ -59,6 +60,21 @@ public class ExceptionControllerAdvice {
         detail.setDetail(ex.getLocalizedMessage());
         detail.setProperty("timestamp", Instant.now());
         return detail;
+    }
+
+    /**
+     * Handles {@link AccessDeniedException} by returning a 403 Forbidden status.
+     *
+     * @param e The {@link AccessDeniedException} to be handled
+     * @param request {@link HttpServletRequest} object referring to the current request.
+     * @return A {@link ResponseEntity} containing the error information and a 403 Forbidden status
+     */
+    @ExceptionHandler(AccessDeniedException.class)
+    @ResponseBody
+    public ResponseEntity<ProblemDetail> handleAccessDeniedException(AccessDeniedException e, HttpServletRequest request) {
+        HttpStatus status = HttpStatus.FORBIDDEN;
+        ProblemDetail detail = this.detailBuild(e, status, request.getRequestURL());
+        return ResponseEntity.status(status).body(detail);
     }
 
     /**

--- a/src/main/java/org/springframework/samples/petclinic/security/OAuth2UserMapper.java
+++ b/src/main/java/org/springframework/samples/petclinic/security/OAuth2UserMapper.java
@@ -2,12 +2,30 @@ package org.springframework.samples.petclinic.security;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
+import org.springframework.samples.petclinic.model.Role;
 import org.springframework.samples.petclinic.model.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
 
 @Component
 public class OAuth2UserMapper {
+
+    /**
+     * Maps database roles to Spring Security GrantedAuthorities.
+     */
+    public Set<GrantedAuthority> mapToAuthorities(Set<Role> roles) {
+        if (roles == null) {
+            return Set.of();
+        }
+        return roles.stream()
+            .map(Role::getName)
+            .map(SimpleGrantedAuthority::new)
+            .collect(Collectors.toSet());
+    }
 
     /**
      * Maps OAuth2 attributes to a PetClinic User entity.

--- a/src/main/java/org/springframework/samples/petclinic/security/PetClinicOAuth2UserService.java
+++ b/src/main/java/org/springframework/samples/petclinic/security/PetClinicOAuth2UserService.java
@@ -11,6 +11,7 @@ import org.springframework.samples.petclinic.repository.UserRepository;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,11 +36,17 @@ public class PetClinicOAuth2UserService extends DefaultOAuth2UserService {
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
         OAuth2User oAuth2User = super.loadUser(userRequest);
         String provider = userRequest.getClientRegistration().getRegistrationId();
-        processOAuth2User(oAuth2User.getAttributes(), provider);
-        return oAuth2User;
+        User user = processOAuth2User(oAuth2User.getAttributes(), provider);
+        
+        return new DefaultOAuth2User(
+            userMapper.mapToAuthorities(user.getRoles()), 
+            oAuth2User.getAttributes(), 
+            userRequest.getClientRegistration().getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName()
+        );
     }
-
-    public void processOAuth2User(Map<String, Object> attributes, String provider) {
+    
+    @Transactional
+    public User processOAuth2User(Map<String, Object> attributes, String provider) {
         User user = userMapper.mapToUser(attributes, provider);
         Optional<User> existing = userRepository.findByUsername(user.getUsername());
         if (existing.isPresent()) {
@@ -51,9 +58,11 @@ public class PetClinicOAuth2UserService extends DefaultOAuth2UserService {
             existingUser.setOauthId(user.getOauthId());
             existingUser.setOauthProvider(user.getOauthProvider());
             userRepository.save(existingUser);
+            return existingUser;
         } else {
             assignRoles(user);
             userRepository.save(user);
+            return user;
         }
     }
 

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/AuthControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/AuthControllerTests.java
@@ -1,0 +1,47 @@
+package org.springframework.samples.petclinic.rest.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.*;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class AuthControllerTests extends OAuthIntegrationIT {
+
+    @Test
+    void testUserDetailsAndRolesStorage() throws Exception {
+        setupOAuth2StubsForUser("admin@example.com", "Admin", "User", "google-admin");
+
+        String sessionCookie = createOAuth2Session();
+        assertNotNull(sessionCookie, "OAuth2 login should create a session cookie");
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Cookie", sessionCookie);
+
+        ResponseEntity<String> userResponse = restTemplate.exchange(
+                baseUrl + "/api/session/user", HttpMethod.GET, new HttpEntity<>(headers), String.class);
+
+        assertTrue(userResponse.getStatusCode().is2xxSuccessful(), "/api/session/user should return 2xx after login");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> responseBody = objectMapper.readValue(userResponse.getBody(), Map.class);
+
+        // Verify OAuth2 user details are stored
+        assertEquals("admin@example.com", responseBody.get("email"));
+        assertEquals("Admin", responseBody.get("firstName"));
+        assertEquals("User", responseBody.get("lastName"));
+
+        // Verify roles are assigned and stored
+        assertNotNull(responseBody.get("roles"));
+        @SuppressWarnings("unchecked")
+        List<String> roles = (List<String>) responseBody.get("roles");
+        assertFalse(roles.isEmpty(), "Admin user should have roles assigned");
+
+        assertTrue(roles.contains("ROLE_ADMIN"), "Admin user should have ROLE_ADMIN role");
+        assertTrue(roles.contains("ROLE_VET_ADMIN"), "Admin user should have ROLE_VET_ADMIN role");
+        assertTrue(roles.contains("ROLE_OWNER_ADMIN"), "Admin user should have ROLE_OWNER_ADMIN role");
+        assertEquals(3, roles.size(), "Admin user should have exactly 3 roles");
+    }
+
+}

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/OAuthIntegrationIT.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/OAuthIntegrationIT.java
@@ -1,0 +1,201 @@
+package org.springframework.samples.petclinic.rest.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import org.apache.hc.client5.http.cookie.BasicCookieStore;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.*;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.List;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public abstract class OAuthIntegrationIT {
+
+    protected static WireMockServer wireMockServer;
+
+    @LocalServerPort
+    protected int port;
+
+    @Autowired
+    protected TestRestTemplate restTemplate;
+
+    protected RestTemplate oauthTemplate;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    protected String baseUrl;
+
+    @DynamicPropertySource
+    static void registerProps(DynamicPropertyRegistry registry) {
+        wireMockServer = new WireMockServer(options()
+                .dynamicPort()
+                .extensions(new com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer(true)));
+        wireMockServer.start();
+
+        registry.add("spring.security.oauth2.client.provider.google.authorization-uri",
+                () -> "http://localhost:" + wireMockServer.port() + "/oauth2/authorize");
+        registry.add("spring.security.oauth2.client.provider.google.token-uri",
+                () -> "http://localhost:" + wireMockServer.port() + "/oauth2/token");
+        registry.add("spring.security.oauth2.client.provider.google.user-info-uri",
+                () -> "http://localhost:" + wireMockServer.port() + "/oauth2/userinfo");
+        registry.add("spring.security.oauth2.client.provider.google.user-name-attribute", () -> "email");
+
+        registry.add("spring.security.oauth2.client.registration.google.client-id", () -> "test-client-id");
+        registry.add("spring.security.oauth2.client.registration.google.client-secret", () -> "test-client-secret");
+        registry.add("spring.security.oauth2.client.registration.google.scope", () -> "email,profile");
+
+        registry.add("spring.session.timeout", () -> "30m");
+
+        registry.add("petclinic.security.oauth2.enable", () -> "true");
+        registry.add("petclinic.security.enable", () -> "false");
+
+        registry.add("petclinic.security.oauth2.admin-emails",
+            () -> "admin@example.com:ADMIN,VET_ADMIN,OWNER_ADMIN;vet-admin@example.com:VET_ADMIN;owner-admin@example.com:OWNER_ADMIN");
+    }
+
+    @BeforeEach
+    void setUp() {
+        baseUrl = "http://localhost:" + port + "/petclinic";
+        wireMockServer.resetAll();
+
+        BasicCookieStore cookieStore = new BasicCookieStore();
+
+        CloseableHttpClient httpClient = HttpClients.custom()
+                .setDefaultCookieStore(cookieStore)
+                .disableRedirectHandling()
+                .build();
+
+        HttpComponentsClientHttpRequestFactory factory =
+                new HttpComponentsClientHttpRequestFactory(httpClient);
+
+        oauthTemplate = new RestTemplate(factory);
+    }
+
+    protected void setupOAuth2StubsForUser(String email, String firstName, String lastName, String sub) {
+        wireMockServer.stubFor(get(urlMatching("/oauth2/authorize.*"))
+                .willReturn(aResponse()
+                        .withStatus(302)
+                        .withHeader("Location",
+                                "http://localhost:" + port + "/petclinic/login/oauth2/code/google?code=test-code&state={{{request.query.state}}}")
+                        .withTransformers("response-template")));
+
+        wireMockServer.stubFor(post(urlEqualTo("/oauth2/token"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                        {
+                          "access_token": "mock-access-token",
+                          "token_type": "Bearer",
+                          "expires_in": 3600
+                        }
+                        """)));
+
+        wireMockServer.stubFor(get(urlEqualTo("/oauth2/userinfo"))
+                .withHeader("Authorization", equalTo("Bearer mock-access-token"))
+                .willReturn(okJson("""
+                        {
+                          "sub": "%s",
+                          "email": "%s",
+                          "name": "%s %s",
+                          "given_name": "%s",
+                          "family_name": "%s",
+                          "picture": "https://example.com/avatar.png"
+                        }
+                        """.formatted(sub, email, firstName, lastName, firstName, lastName))));
+    }
+
+    protected String createOAuth2Session() {
+        try {
+            ResponseEntity<String> step1 = oauthTemplate.getForEntity(
+                    baseUrl + "/oauth2/authorization/google", String.class);
+
+            String stateCookie = extractCookieFromResponse(step1);
+            String redirectToProvider = step1.getHeaders().getFirst("Location");
+
+            if (redirectToProvider == null) {
+                return null;
+            }
+
+            HttpHeaders headers1 = new HttpHeaders();
+            if (stateCookie != null) {
+                headers1.set("Cookie", stateCookie);
+            }
+            ResponseEntity<String> step2 = oauthTemplate.exchange(
+                    URI.create(redirectToProvider), HttpMethod.GET, new HttpEntity<>(headers1), String.class);
+
+            String callbackUrl = step2.getHeaders().getFirst("Location");
+
+            if (callbackUrl == null) {
+                return null;
+            }
+
+            HttpHeaders headers2 = new HttpHeaders();
+            if (stateCookie != null) {
+                headers2.set("Cookie", stateCookie);
+            }
+            ResponseEntity<String> step3 = oauthTemplate.exchange(
+                    URI.create(callbackUrl), HttpMethod.GET, new HttpEntity<>(headers2), String.class);
+
+            String sessionCookie = extractCookieFromResponse(step3);
+
+            String finalCookie;
+            if (sessionCookie != null) {
+                finalCookie = stateCookie != null ? stateCookie + "; " + sessionCookie : sessionCookie;
+            } else {
+                finalCookie = stateCookie;
+            }
+
+            if (finalCookie != null) {
+                Awaitility.await()
+                    .atMost(Duration.ofSeconds(5))
+                    .pollInterval(Duration.ofMillis(100))
+                    .untilAsserted(() -> {
+                        try {
+                            wireMockServer.verify(postRequestedFor(urlEqualTo("/oauth2/token")));
+                        } catch (Exception e) {
+                            throw new AssertionError("Token endpoint not called yet");
+                        }
+                    });
+            }
+
+            return finalCookie;
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to complete OAuth2 login flow", e);
+        }
+    }
+
+    private String extractCookieFromResponse(ResponseEntity<?> response) {
+        List<String> cookies = response.getHeaders().get(HttpHeaders.SET_COOKIE);
+        if (cookies == null || cookies.isEmpty()) {
+            return null;
+        }
+        StringBuilder cookieHeader = new StringBuilder();
+        for (String cookie : cookies) {
+            String nameValue = cookie.split(";")[0].trim();
+            if (!cookieHeader.isEmpty()) {
+                cookieHeader.append("; ");
+            }
+            cookieHeader.append(nameValue);
+        }
+        return !cookieHeader.isEmpty() ? cookieHeader.toString() : null;
+    }
+
+}

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/OwnerRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/OwnerRestControllerTests.java
@@ -492,4 +492,12 @@ class OwnerRestControllerTests {
             .andExpect(status().isNotFound());
     }
 
+    @Test
+    @WithMockUser(roles = "USER")
+    void testListOwnersForbiddenForNonAdmin() throws Exception {
+        this.mockMvc.perform(get("/api/owners")
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isForbidden());
+    }
+
 }

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/PetRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/PetRestControllerTests.java
@@ -219,4 +219,12 @@ class PetRestControllerTests {
             .andExpect(status().isNotFound());
     }
 
+    @Test
+    @WithMockUser(roles = "USER")
+    void testGetPetForbiddenForNonAdmin() throws Exception {
+        this.mockMvc.perform(get("/api/pets/1")
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isForbidden());
+    }
+
 }

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/PetTypeRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/PetTypeRestControllerTests.java
@@ -250,4 +250,12 @@ class PetTypeRestControllerTests {
         	.andExpect(status().isNotFound());
     }
 
+    @Test
+    @WithMockUser(roles="USER")
+    void testGetPetTypeForbiddenForNonAdmin() throws Exception {
+    	this.mockMvc.perform(get("/api/pettypes/1")
+    		.accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isForbidden());
+    }
+
 }

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/RoleAuthIntegrationTest.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/RoleAuthIntegrationTest.java
@@ -1,0 +1,165 @@
+package org.springframework.samples.petclinic.rest.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class RoleAuthIntegrationTest extends OAuthIntegrationIT {
+
+    @Test
+    void testGetVets() {
+        HttpHeaders headers = loginAsAdmin();
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                baseUrl + "/api/vets", HttpMethod.GET, new HttpEntity<>(headers), String.class);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode(),
+                "OAuth2 user with VET_ADMIN role should access /api/vets");
+    }
+
+    @Test
+    void testGetOwners() {
+        HttpHeaders headers = loginAsAdmin();
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                baseUrl + "/api/owners", HttpMethod.GET, new HttpEntity<>(headers), String.class);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode(),
+                "OAuth2 user with OWNER_ADMIN role should access /api/owners");
+    }
+
+    @Test
+    void testGetPet() {
+        HttpHeaders headers = loginAsAdmin();
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                baseUrl + "/api/pets/3", HttpMethod.GET, new HttpEntity<>(headers), String.class);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode(),
+                "OAuth2 user with OWNER_ADMIN role should access /api/pets/{id}");
+    }
+
+    @Test
+    void testGetPetType() {
+        HttpHeaders headers = loginAsAdmin();
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                baseUrl + "/api/pettypes/1", HttpMethod.GET, new HttpEntity<>(headers), String.class);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode(),
+                "OAuth2 user with VET_ADMIN role should access /api/pettypes/{id}");
+    }
+
+    @Test
+    void testGetSpecialty() {
+        HttpHeaders headers = loginAsAdmin();
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                baseUrl + "/api/specialties/1", HttpMethod.GET, new HttpEntity<>(headers), String.class);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode(),
+                "OAuth2 user with VET_ADMIN role should access /api/specialties/{id}");
+    }
+
+    @Test
+    void testGetVisit() {
+        HttpHeaders headers = loginAsAdmin();
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                baseUrl + "/api/visits/1", HttpMethod.GET, new HttpEntity<>(headers), String.class);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode(),
+                "OAuth2 user with OWNER_ADMIN role should access /api/visits/{id}");
+    }
+
+    @Test
+    void testGetVetsForbiddenForRegularUser() {
+        HttpHeaders headers = loginAsRegularUser();
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                baseUrl + "/api/vets", HttpMethod.GET, new HttpEntity<>(headers), String.class);
+
+        assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode(),
+                "OAuth2 user without VET_ADMIN role should get 403 on /api/vets");
+    }
+
+    @Test
+    void testGetOwnersForbiddenForRegularUser() {
+        HttpHeaders headers = loginAsRegularUser();
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                baseUrl + "/api/owners", HttpMethod.GET, new HttpEntity<>(headers), String.class);
+
+        assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode(),
+                "OAuth2 user without OWNER_ADMIN role should get 403 on /api/owners");
+    }
+
+    @Test
+    void testGetPetForbiddenForRegularUser() {
+        HttpHeaders headers = loginAsRegularUser();
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                baseUrl + "/api/pets/3", HttpMethod.GET, new HttpEntity<>(headers), String.class);
+
+        assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode(),
+                "OAuth2 user without OWNER_ADMIN role should get 403 on /api/pets/{id}");
+    }
+
+    @Test
+    void testGetPetTypeForbiddenForRegularUser() {
+        HttpHeaders headers = loginAsRegularUser();
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                baseUrl + "/api/pettypes/1", HttpMethod.GET, new HttpEntity<>(headers), String.class);
+
+        assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode(),
+                "OAuth2 user without VET_ADMIN role should get 403 on /api/pettypes/{id}");
+    }
+
+    @Test
+    void testGetSpecialtyForbiddenForRegularUser() {
+        HttpHeaders headers = loginAsRegularUser();
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                baseUrl + "/api/specialties/1", HttpMethod.GET, new HttpEntity<>(headers), String.class);
+
+        assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode(),
+                "OAuth2 user without VET_ADMIN role should get 403 on /api/specialties/{id}");
+    }
+
+    @Test
+    void testGetVisitForbiddenForRegularUser() {
+        HttpHeaders headers = loginAsRegularUser();
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                baseUrl + "/api/visits/1", HttpMethod.GET, new HttpEntity<>(headers), String.class);
+
+        assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode(),
+                "OAuth2 user without OWNER_ADMIN role should get 403 on /api/visits/{id}");
+    }
+
+    private HttpHeaders loginAsAdmin() {
+        setupOAuth2StubsForUser("admin@example.com", "Admin", "User", "google-admin");
+
+        String sessionCookie = createOAuth2Session();
+        assertNotNull(sessionCookie, "OAuth2 login should create a session cookie");
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Cookie", sessionCookie);
+        headers.set("Accept", "application/json");
+        return headers;
+    }
+
+    private HttpHeaders loginAsRegularUser() {
+        setupOAuth2StubsForUser("regular@example.com", "Regular", "User", "google-regular");
+
+        String sessionCookie = createOAuth2Session();
+        assertNotNull(sessionCookie, "OAuth2 login should create a session cookie");
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Cookie", sessionCookie);
+        headers.set("Accept", "application/json");
+        return headers;
+    }
+}

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/SpecialtyRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/SpecialtyRestControllerTests.java
@@ -215,4 +215,12 @@ class SpecialtyRestControllerTests {
     		.content(newSpecialtyAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
         	.andExpect(status().isNotFound());
     }
+
+    @Test
+    @WithMockUser(roles="USER")
+    void testGetSpecialtyForbiddenForNonAdmin() throws Exception {
+    	this.mockMvc.perform(get("/api/specialties/1")
+    		.accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isForbidden());
+    }
 }

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/UserRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/UserRestControllerTests.java
@@ -44,18 +44,21 @@ class UserRestControllerTests {
             .setControllerAdvice(new ExceptionControllerAdvice()).build();
     }
 
-    @Test
-    @WithMockUser(roles = "ADMIN")
-    void testCreateUserSuccess() throws Exception {
+    private String createValidUserJSON() throws Exception {
         User user = new User();
         user.setUsername("username");
         user.setPassword("password");
         user.setEnabled(true);
         user.addRole("OWNER_ADMIN");
         ObjectMapper mapper = new ObjectMapper();
-        String newVetAsJSON = mapper.writeValueAsString(userMapper.toUserDto(user));
+        return mapper.writeValueAsString(userMapper.toUserDto(user));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void testCreateUserSuccess() throws Exception {
         this.mockMvc.perform(post("/api/users")
-            .content(newVetAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+            .content(createValidUserJSON()).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(status().isCreated());
     }
 
@@ -71,5 +74,13 @@ class UserRestControllerTests {
         this.mockMvc.perform(post("/api/users")
             .content(newVetAsJSON).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void testCreateUserForbiddenForNonAdmin() throws Exception {
+        this.mockMvc.perform(post("/api/users")
+                .content(createValidUserJSON()).accept(MediaType.APPLICATION_JSON_VALUE).contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isForbidden());
     }
 }

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/VetRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/VetRestControllerTests.java
@@ -208,6 +208,15 @@ class VetRestControllerTests {
     }
 
     @Test
+    @WithMockUser(roles="USER")
+    void testGetAllVetsForbiddenForNonAdmin() throws Exception {
+    	given(this.clinicService.findAllVets()).willReturn(vets);
+        this.mockMvc.perform(get("/api/vets")
+        	.accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
     @WithMockUser(roles="VET_ADMIN")
     void testDeleteVetError() throws Exception {
     	Vet newVet = vets.get(0);

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/VisitRestControllerTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/VisitRestControllerTests.java
@@ -251,4 +251,12 @@ class VisitRestControllerTests {
         	.andExpect(status().isNotFound());
     }
 
+    @Test
+    @WithMockUser(roles="USER")
+    void testGetVisitForbiddenForNonAdmin() throws Exception {
+    	this.mockMvc.perform(get("/api/visits/1")
+    		.accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isForbidden());
+    }
+
 }


### PR DESCRIPTION
## Description

All endpoints that require user roles return `500 Internal Server Error`, regardless of the roles assigned to the user. 
Endpoints that only require general authentication but not roles (like `GET /api/session/user`) work fine.

## Steps to Reproduce

1. Authorize as admin user
  - I verified it just in case: `GET /petclinic/api/session/user` returns the user info.
2. Calling `GET /petclinic/api/vets` with the same session cookie returns 500 instead of proper response

Another scenario:
1. Authorize as a normal user
2. Call `GET /petclinic/api/vets` also returns 500 instead of `403 Forbidden`.