### PR TITLE
Owner with ROLE_OWNER cannot view their own pet

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -6,7 +6,8 @@
   "build_system": "maven",
   "expected": {
     "fail_to_pass": [
-      "SecurityIntegrationTests"
+      "org.springframework.samples.petclinic.rest.controller.SecurityIntegrationTests.ownerCanAccessOwnPet",
+      "org.springframework.samples.petclinic.rest.controller.SecurityIntegrationTests.ownerCanCreateAndUpdateOwnPet"
     ],
     "pass_to_pass": []
   },

--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,9 @@
   "jvm_version": "21",
   "build_system": "maven",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "SecurityIntegrationTests"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/src/main/java/org/springframework/samples/petclinic/rest/controller/PetRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/rest/controller/PetRestController.java
@@ -49,7 +49,7 @@ public class PetRestController implements PetsApi {
         this.petMapper = petMapper;
     }
 
-    @PreAuthorize("hasRole(@roles.OWNER_ADMIN)")
+    @PreAuthorize("hasRole(@roles.OWNER_ADMIN) or (hasRole(@roles.OWNER) and @ownershipChecker.isPetOwner(authentication, #petId))")
     @Override
     public ResponseEntity<PetDto> getPet(Integer petId) {
         PetDto pet = petMapper.toPetDto(this.clinicService.findPetById(petId));

--- a/src/main/java/org/springframework/samples/petclinic/security/OwnershipChecker.java
+++ b/src/main/java/org/springframework/samples/petclinic/security/OwnershipChecker.java
@@ -1,6 +1,7 @@
 package org.springframework.samples.petclinic.security;
 
 import org.springframework.samples.petclinic.model.Owner;
+import org.springframework.samples.petclinic.model.Pet;
 import org.springframework.samples.petclinic.model.Vet;
 import org.springframework.samples.petclinic.service.ClinicService;
 import org.springframework.security.core.Authentication;
@@ -31,5 +32,21 @@ public class OwnershipChecker {
         Vet vet = clinicService.findVetById(vetId);
         return vet != null && vet.getUsername() != null
             && vet.getUsername().equals(authentication.getName());
+    }
+
+    public boolean isPetOwner(Authentication authentication, int petId) {
+        if (authentication == null) {
+            return false;
+        }
+        Pet pet = clinicService.findPetById(petId);
+        if (pet == null || pet.getOwner() == null) {
+            return false;
+        }
+        Owner owner = pet.getOwner();
+        // Handle skeleton owner objects in same transaction
+        if (owner.getUsername() == null) {
+            owner = clinicService.findOwnerById(owner.getId());
+        }
+        return owner != null && authentication.getName().equals(owner.getUsername());
     }
 }

--- a/src/test/java/org/springframework/samples/petclinic/rest/controller/SecurityIntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/rest/controller/SecurityIntegrationTests.java
@@ -139,6 +139,60 @@ class SecurityIntegrationTests {
 
     @Test
     @WithMockUser(username = "owner1", roles = {"OWNER"})
+    void ownerCanAccessOwnPet() throws Exception {
+        mockMvc.perform(get("/api/pets/1")
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(1));
+    }
+
+    @Test
+    @WithMockUser(username = "owner1", roles = {"OWNER"})
+    void ownerCanCreateAndUpdateOwnPet() throws Exception {
+        String petJson = "{\"name\":\"SecondPet\",\"birthDate\":\"2020-01-01\",\"type\":{\"id\":1,\"name\":\"cat\"}}";
+
+        String response = mockMvc.perform(post("/api/owners/1/pets")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(petJson)
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isCreated())
+            .andReturn().getResponse().getContentAsString();
+
+        Integer newPetId = com.jayway.jsonpath.JsonPath.parse(response).read("$.id");
+
+        mockMvc.perform(get("/api/pets/" + newPetId)
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(newPetId))
+            .andExpect(jsonPath("$.name").value("SecondPet"));
+
+        String updatedPetJson = "{\"id\":" + newPetId + ",\"name\":\"UpdatedPet\",\"birthDate\":\"2020-01-01\",\"type\":{\"id\":1,\"name\":\"cat\"}}";
+
+        mockMvc.perform(put("/api/owners/1/pets/" + newPetId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(updatedPetJson)
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @WithMockUser(username = "owner1", roles = {"OWNER"})
+    void ownerCannotAccessOtherOwnerPet() throws Exception {
+        mockMvc.perform(get("/api/pets/2")
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(username = "owner1", roles = {"OWNER"})
+    void ownerCannotAccessNonExistentPet() throws Exception {
+        mockMvc.perform(get("/api/pets/9999")
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(username = "owner1", roles = {"OWNER"})
     void ownerCannotAccessOtherOwnerProfile() throws Exception {
         mockMvc.perform(get("/api/owners/2").accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isForbidden());
@@ -168,6 +222,13 @@ class SecurityIntegrationTests {
     }
 
     @Test
+    @WithMockUser(username = "admin", roles = {"OWNER_ADMIN"})
+    void ownerAdminCanAccessAnyPet() throws Exception {
+        mockMvc.perform(get("/api/pets/1").accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk());
+    }
+
+    @Test
     @WithMockUser(username = "admin", roles = {"VET_ADMIN"})
     void vetAdminCanAccessAnyVet() throws Exception {
         mockMvc.perform(get("/api/vets/1").accept(MediaType.APPLICATION_JSON))
@@ -189,6 +250,12 @@ class SecurityIntegrationTests {
     @Test
     void unauthenticatedCannotAccessOwners() throws Exception {
         mockMvc.perform(get("/api/owners").accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void unauthenticatedCannotAccessPet() throws Exception {
+        mockMvc.perform(get("/api/pets/1").accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isUnauthorized());
     }
 


### PR DESCRIPTION
## Description

A user authenticated as an owner (`ROLE_OWNER`) receives a `403 Forbidden` response when trying to access their own pet
through `GET /api/pets/{petId}`, even though the pet belongs to him.

## Steps to Reproduce

1. Authenticate as `owner1` (a user with `ROLE_OWNER` who owns pet with id `1`).
2. Send `GET /api/pets/1` – receives `403 Forbidden` instead of `200 OK` with pet data.

Other ownership-based operations work correctly for the same user:
e.g. `GET /api/owners/1`, `PUT /api/owners/1/pets/1`, `POST /api/owners/1/pets`